### PR TITLE
More Main Chart UI

### DIFF
--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -25,8 +25,9 @@
   let xTicks: Array<number>;
 
   let brushExtents = [null, null];
-  let brushedData: Array<Object>;
   let groupedBrushedData: Array<Object>;
+
+  let brushFaded = true;
 
   const fillEmptyFrames = (
     data: Array<FrameRecord>,
@@ -56,18 +57,6 @@
   };
 
   $: {
-    const startFrame = Math.max(
-      1,
-      Math.ceil($currentVideo.frame_count * (brushExtents[0] || 0)),
-    );
-    const endFrame = Math.min(
-      $currentVideo.frame_count,
-      Math.ceil($currentVideo.frame_count * (brushExtents[1] || 1)),
-    );
-    brushedData = fillEmptyFrames(data, startFrame, endFrame);
-  }
-
-  $: {
     groupedData = groupLonger(fillEmptyFrames(data), seriesNames, {
       groupTo: "series",
       valueTo: "value",
@@ -79,10 +68,22 @@
   }
 
   $: {
-    groupedBrushedData = groupLonger(brushedData, seriesNames, {
-      groupTo: "series",
-      valueTo: "value",
-    });
+    const startFrame = Math.max(
+      1,
+      Math.ceil($currentVideo.frame_count * (brushExtents[0] || 0)),
+    );
+    const endFrame = Math.min(
+      $currentVideo.frame_count,
+      Math.ceil($currentVideo.frame_count * (brushExtents[1] || 1)),
+    );
+    groupedBrushedData = groupLonger(
+      fillEmptyFrames(data, startFrame, endFrame),
+      seriesNames,
+      {
+        groupTo: "series",
+        valueTo: "value",
+      },
+    );
   }
 </script>
 
@@ -117,7 +118,12 @@
   </LayerCake>
 </div>
 
-<div class="brush-container variant-ringed-primary select-none pt-2">
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<div
+  class="brush-container variant-ringed-primary select-none pt-2"
+  on:mouseover={() => (brushFaded = false)}
+  on:mouseout={() => (brushFaded = true)}
+>
   <LayerCake
     padding={{ top: 7, right: 10, bottom: 20, left: 25 }}
     x={"frame"}
@@ -137,7 +143,7 @@
         snapTicks={true}
         tickMarks={true}
       />
-      <MultiLine />
+      <MultiLine faded={brushFaded} />
     </Svg>
     <Html>
       <Brush bind:min={brushExtents[0]} bind:max={brushExtents[1]} />

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -4,7 +4,7 @@
 
   import AxisX from "@layercake/AxisX.svelte";
   import AxisY from "@layercake/AxisY.svelte";
-  import Labels from "@layercake/GroupLabels.html.svelte";
+  import Key from "@layercake/Key.html.svelte";
   import MultiLine from "@layercake/MultiLine.svelte";
   import SharedTooltip from "@layercake/SharedTooltip.html.svelte";
 
@@ -17,6 +17,8 @@
   const formatTickY = (d: unknown) => d;
 
   const seriesNames = Object.keys(data[0]!).filter((d) => d !== "frame");
+
+  let hiddenSeries: Array<string> = [];
 
   let groupedData: Array<Object>;
   let xTicks: Array<number>;
@@ -54,12 +56,12 @@
         tickMarks={true}
       />
       <AxisY ticks={5} formatTick={formatTickY} />
-      <MultiLine />
+      <MultiLine {hiddenSeries} />
     </Svg>
 
     <Html>
-      <Labels />
       <SharedTooltip formatTitle={(d) => `Frame ${d}`} dataset={data} />
+      <Key align="end" bind:hiddenSeries />
     </Html>
   </LayerCake>
 </div>

--- a/web-ui/src/svelte/layercake/Brush.html.svelte
+++ b/web-ui/src/svelte/layercake/Brush.html.svelte
@@ -3,7 +3,7 @@
   Adds a brush component to create a range between 0 and 1. Bind to the `min` and `max` props to use them in other components. See the [brushable example](https://layercake.graphcics/example/Brush) for use.
  -->
 <script>
-  import { clamp } from "yootils";
+  import { clamp } from "@utils";
 
   /** @type {Number} min - The brush's min value. Useful to bind to. */
   export let min;

--- a/web-ui/src/svelte/layercake/Brush.html.svelte
+++ b/web-ui/src/svelte/layercake/Brush.html.svelte
@@ -1,0 +1,154 @@
+<!--
+  @component
+  Adds a brush component to create a range between 0 and 1. Bind to the `min` and `max` props to use them in other components. See the [brushable example](https://layercake.graphcics/example/Brush) for use.
+ -->
+<script>
+  import { clamp } from "yootils";
+
+  /** @type {Number} min - The brush's min value. Useful to bind to. */
+  export let min;
+
+  /** @type {Number} max - The brush's max value. Useful to bind to. */
+  export let max;
+
+  let brush;
+
+  const p = (x) => {
+    const { left, right } = brush.getBoundingClientRect();
+    return clamp((x - left) / (right - left), 0, 1);
+  };
+
+  const handler = (fn) => {
+    return (e) => {
+      if (e.type === "touchstart") {
+        if (e.touches.length !== 1) return;
+        e = e.touches[0];
+      }
+
+      const id = e.identifier;
+      const start = { min, max, p: p(e.clientX) };
+
+      const handle_move = (e) => {
+        if (e.type === "touchmove") {
+          if (e.changedTouches.length !== 1) return;
+          e = e.changedTouches[0];
+          if (e.identifier !== id) return;
+        }
+
+        fn(start, p(e.clientX));
+      };
+
+      const handle_end = (e) => {
+        if (e.type === "touchend") {
+          if (e.changedTouches.length !== 1) return;
+          if (e.changedTouches[0].identifier !== id) return;
+        } else if (e.target === brush) {
+          clear();
+        }
+
+        window.removeEventListener("mousemove", handle_move);
+        window.removeEventListener("mouseup", handle_end);
+
+        window.removeEventListener("touchmove", handle_move);
+        window.removeEventListener("touchend", handle_end);
+      };
+
+      window.addEventListener("mousemove", handle_move);
+      window.addEventListener("mouseup", handle_end);
+
+      window.addEventListener("touchmove", handle_move);
+      window.addEventListener("touchend", handle_end);
+    };
+  };
+
+  const clear = () => {
+    min = null;
+    max = null;
+  };
+
+  const reset = handler((start, p) => {
+    min = clamp(Math.min(start.p, p), 0, 1);
+    max = clamp(Math.max(start.p, p), 0, 1);
+  });
+
+  const move = handler((start, p) => {
+    const d = clamp(p - start.p, -start.min, 1 - start.max);
+    min = start.min + d;
+    max = start.max + d;
+  });
+
+  const adjust_min = handler((start, p) => {
+    min = p > start.max ? start.max : p;
+    max = p > start.max ? p : start.max;
+  });
+
+  const adjust_max = handler((start, p) => {
+    min = p < start.min ? p : start.min;
+    max = p < start.min ? start.min : p;
+  });
+
+  $: left = 100 * min;
+  $: right = 100 * (1 - max);
+</script>
+
+<div
+  bind:this={brush}
+  class="brush-outer"
+  on:mousedown|stopPropagation={reset}
+  on:touchstart|stopPropagation={reset}
+>
+  {#if min !== null}
+    <div
+      class="brush-inner"
+      on:mousedown|stopPropagation={move}
+      on:touchstart|stopPropagation={move}
+      style="left: {left}%; right: {right}%"
+    />
+    <div
+      class="brush-handle"
+      on:mousedown|stopPropagation={adjust_min}
+      on:touchstart|stopPropagation={adjust_min}
+      style="left: {left}%"
+    />
+    <div
+      class="brush-handle"
+      on:mousedown|stopPropagation={adjust_max}
+      on:touchstart|stopPropagation={adjust_max}
+      style="right: {right}%"
+    />
+  {/if}
+</div>
+
+<style>
+  .brush-outer {
+    position: relative;
+    width: 100%;
+    height: calc(100% + 5px);
+    top: -5px;
+  }
+
+  .brush-inner {
+    position: absolute;
+    height: 100%;
+    cursor: move;
+    /* mix-blend-mode: difference; */
+    background-color: #cccccc90;
+    /* border: 1px solid #000; */
+  }
+
+  .brush-handle {
+    position: absolute;
+    width: 0;
+    height: 100%;
+    cursor: ew-resize;
+  }
+
+  .brush-handle::before {
+    position: absolute;
+    content: "";
+    width: 8px;
+    left: -4px;
+    height: 100%;
+    background: transparent;
+  }
+</style>

--- a/web-ui/src/svelte/layercake/Brush.html.svelte
+++ b/web-ui/src/svelte/layercake/Brush.html.svelte
@@ -131,9 +131,9 @@
     position: absolute;
     height: 100%;
     cursor: move;
-    /* mix-blend-mode: difference; */
-    background-color: #cccccc90;
-    /* border: 1px solid #000; */
+    background-color: #00000010;
+    mix-blend-mode: darken;
+    outline: 1px solid #00000030;
   }
 
   .brush-handle {

--- a/web-ui/src/svelte/layercake/Key.html.svelte
+++ b/web-ui/src/svelte/layercake/Key.html.svelte
@@ -17,6 +17,8 @@
   /** @type {Boolean} [capitalize=true] - Capitalize the first character. */
   export let capitalize = true;
 
+  export let hiddenSeries;
+
   const { zDomain, zScale } = getContext("LayerCake");
 
   function cap(val) {
@@ -36,7 +38,14 @@
   style="justify-content: {align === 'end' ? 'flex-end' : align};"
 >
   {#each $zDomain as item}
-    <div class="key-item">
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <div
+      class="key-item"
+      on:click={() =>
+        hiddenSeries.includes(item)
+          ? (hiddenSeries = hiddenSeries.filter((d) => d !== item))
+          : (hiddenSeries = [...hiddenSeries, item])}
+    >
       <div
         class="chip chip__{shape}"
         style="background: {shape === `line`
@@ -53,8 +62,12 @@
 <style>
   .key {
     display: flex;
+    float: right;
+    position: relative;
+    width: fit-content;
   }
   .key-item {
+    cursor: pointer;
     margin-right: 14px;
   }
   .chip {

--- a/web-ui/src/svelte/layercake/Key.html.svelte
+++ b/web-ui/src/svelte/layercake/Key.html.svelte
@@ -1,0 +1,83 @@
+<!--
+  @component
+  Creates a key for ordinal scales on `zScale`.
+ -->
+<script>
+  import { getContext } from "svelte";
+
+  /** @type {String} [shape='square'] - The shape for each item. Can be 'circle', 'line', or 'square'; */
+  export let shape = "square";
+
+  /** @type {String} [align='start'] - Sets the CSS flexbox justify-content setting for the box as a whole. Can be 'start', 'center' or 'end'. */
+  export let align = "start";
+
+  /** @type {Function|Object} [lookup] - Either a function that takes the value and returns a formatted string, or an object of values. If a given value is not present in a lookup object, it returns the original value. */
+  export let lookup = undefined;
+
+  /** @type {Boolean} [capitalize=true] - Capitalize the first character. */
+  export let capitalize = true;
+
+  const { zDomain, zScale } = getContext("LayerCake");
+
+  function cap(val) {
+    return String(val).replace(/^\w/, (d) => d.toUpperCase());
+  }
+
+  function displayName(val) {
+    if (lookup) {
+      return typeof lookup === "function" ? lookup(val) : lookup[val] || val;
+    }
+    return capitalize === true ? cap(val) : val;
+  }
+</script>
+
+<div
+  class="key"
+  style="justify-content: {align === 'end' ? 'flex-end' : align};"
+>
+  {#each $zDomain as item}
+    <div class="key-item">
+      <div
+        class="chip chip__{shape}"
+        style="background: {shape === `line`
+          ? `linear-gradient(-45deg, #ffffff 40%, ${$zScale(
+              item,
+            )} 41%, ${$zScale(item)} 59%, #ffffff 60%)`
+          : $zScale(item)};"
+      />
+      <div class="name">{displayName(item)}</div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .key {
+    display: flex;
+  }
+  .key-item {
+    margin-right: 14px;
+  }
+  .chip {
+    display: inline-block;
+    position: relative;
+    width: 12px;
+    height: 12px;
+  }
+  .chip__circle {
+    border-radius: 50%;
+  }
+  .chip__line:after {
+    content: "";
+    position: absolute;
+    border-width: 3px;
+    width: 14px;
+    transform: rotate(-45deg);
+    transform-origin: 14px 5px;
+  }
+  .name {
+    display: inline;
+    font-size: 14px;
+    text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff,
+      1px 1px 0 #fff;
+  }
+</style>

--- a/web-ui/src/svelte/layercake/MultiLine.svelte
+++ b/web-ui/src/svelte/layercake/MultiLine.svelte
@@ -7,6 +7,8 @@
   import { getContext } from "svelte";
   import { currentVideo } from "@svelte/stores";
 
+  export let hiddenSeries = [];
+
   const { data, xGet, yGet, zGet } = getContext("LayerCake");
 
   $: path = (values) => {
@@ -33,7 +35,9 @@
 
 <g class="line-group">
   {#each $data as group}
-    <path class="path-line" d={path(group.values)} stroke={$zGet(group)} />
+    {#if !hiddenSeries.includes(group.series)}
+      <path class="path-line" d={path(group.values)} stroke={$zGet(group)} />
+    {/if}
   {/each}
 </g>
 

--- a/web-ui/src/svelte/layercake/MultiLine.svelte
+++ b/web-ui/src/svelte/layercake/MultiLine.svelte
@@ -8,6 +8,7 @@
   import { currentVideo } from "@svelte/stores";
 
   export let hiddenSeries = [];
+  export let faded = false;
 
   const { data, xGet, yGet, zGet } = getContext("LayerCake");
 
@@ -16,7 +17,7 @@
   };
 </script>
 
-<g class="line-group">
+<g class="line-group transition-opacity" class:opacity-50={faded}>
   {#each $data as group}
     {#if !hiddenSeries.includes(group.series)}
       <path class="path-line" d={path(group.values)} stroke={$zGet(group)} />

--- a/web-ui/src/svelte/layercake/MultiLine.svelte
+++ b/web-ui/src/svelte/layercake/MultiLine.svelte
@@ -12,24 +12,7 @@
   const { data, xGet, yGet, zGet } = getContext("LayerCake");
 
   $: path = (values) => {
-    // fill with zero values for unrepresented frames, so that the series lines
-    //  actually go down to zero on the y axis where appropriate.
-    const out = [];
-    let i = 1;
-    values.forEach((d) => {
-      while (i < d.frame) {
-        out.push($xGet({ frame: i }) + "," + $yGet({ value: 0 }));
-        i++;
-      }
-      out.push($xGet(d) + "," + $yGet(d));
-      i++;
-    });
-    while (i < $currentVideo.frame_count) {
-      out.push($xGet({ frame: i }) + "," + $yGet({ value: 0 }));
-      i++;
-    }
-    return "M" + out.join("L");
-    // return "M" + values.map((d) => $xGet(d) + "," + $yGet(d)).join("L");
+    return "M" + values.map((d) => $xGet(d) + "," + $yGet(d)).join("L");
   };
 </script>
 


### PR DESCRIPTION
This PR adds a couple of bits of UI polish to the main chart.

I'm still not convinced this chart is the right way to organize this data/ui (or, indeed, entirely that this is the data that we should be organizing) -- perhaps a bar/column chart would be an immediate improvement over a line chart?  Dunno.  Anyway, with that in mind, these are some small improvements that are likely to be useful regardless of whether or how much we end up changing tack here.

* Switched the unhelpful series labels for a key/legend
  *  Right now the "chips" are clickable to simply show/hide the series line; no recalculation of the y-axis is attempted
* There's a "brush" functionality to allow zooming in on the chart
  * This was trickier to implement that I'd expected, but the result is useful, I think, and the methodology for handling the data flow is sound.

There still remains a large degree both of room for improvement and flexibility to realize that improvement and evolve in other ways.  Both of these new feature-ettes are based on copying Layer Cake examples into the codebase and then adapting them to work with the specifics of our data; it's a powerful way to work but there aren't any handrails or safety nets, so I've been feeling my way a little cautiously :)