### PR TITLE
Compute and display per-frame aggregated motion

### DIFF
--- a/api/cluster_video_faces.py
+++ b/api/cluster_video_faces.py
@@ -11,9 +11,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import umap
-from mime_db import MimeDb
 from rich.logging import RichHandler
 from sklearn.cluster import KMeans
+
+from mime_db import MimeDb
 
 # from PIL import Image
 

--- a/api/load_shot_boundaries.py
+++ b/api/load_shot_boundaries.py
@@ -8,8 +8,9 @@ import logging
 import pickle
 from pathlib import Path
 
-from mime_db import MimeDb
 from rich.logging import RichHandler
+
+from mime_db import MimeDb
 
 SHOT_DETECT_THRESHOLD = 0.5
 BATCH_SIZE = 1000

--- a/api/match_offline_faces_to_poses.py
+++ b/api/match_offline_faces_to_poses.py
@@ -9,8 +9,9 @@ from pathlib import Path
 
 import jsonlines
 import numpy as np
-from mime_db import MimeDb
 from rich.logging import RichHandler
+
+from mime_db import MimeDb
 
 BATCH_SIZE = 1000
 

--- a/api/mime_db/__init__.py
+++ b/api/mime_db/__init__.py
@@ -28,6 +28,7 @@ class MimeDb:
     """Class to interact with the database."""
 
     from mime_db._data_loading import (
+        add_frame_movement,
         add_pose_faces,
         add_shot_boundaries,
         add_video,

--- a/api/mime_db/_initialization.py
+++ b/api/mime_db/_initialization.py
@@ -31,6 +31,7 @@ async def initialize_db(conn, drop=False) -> None:
             local_shot_prob FLOAT NOT NULL,
             global_shot_prob FLOAT NOT NULL,
             is_shot_boundary BOOLEAN DEFAULT FALSE,
+            total_movement FLOAT DEFAULT 0.0,
             PRIMARY KEY(video_id, frame)
         )
         ;

--- a/api/mime_db/_read_only.py
+++ b/api/mime_db/_read_only.py
@@ -54,8 +54,6 @@ async def get_pose_data_by_frame(self, video_id: UUID) -> list:
                 posefaces.trackct AS "trackCt",
                 posefaces.facect AS "faceCt",
                 posefaces.avgscore AS "avgScore",
-                frame.local_shot_prob AS "localShot",
-                frame.global_shot_prob AS "globalShot",
                 CAST(frame.is_shot_boundary AS INT) AS "isShot"
         FROM (SELECT pose.video_id,
                     pose.frame,
@@ -83,7 +81,7 @@ async def get_pose_data_from_video(self, video_id: UUID) -> list:
 
 async def get_video_shot_boundaries(self, video_id: UUID) -> list:
     return await self._pool.fetch(
-        "SELECT frame, local_shot_prob, global_shot_prob FROM frame WHERE video_id = $1 AND is_shot_boundary ORDER BY frame ASC;",
+        "SELECT frame FROM frame WHERE video_id = $1 AND is_shot_boundary ORDER BY frame ASC;",
         video_id,
     )
 

--- a/api/mime_db/_read_only.py
+++ b/api/mime_db/_read_only.py
@@ -54,7 +54,8 @@ async def get_pose_data_by_frame(self, video_id: UUID) -> list:
                 posefaces.trackct AS "trackCt",
                 posefaces.facect AS "faceCt",
                 posefaces.avgscore AS "avgScore",
-                CAST(frame.is_shot_boundary AS INT) AS "isShot"
+                CAST(frame.is_shot_boundary AS INT) AS "isShot",
+                frame.total_movement AS "movement"
         FROM (SELECT pose.video_id,
                     pose.frame,
                     count(pose.pose_idx) AS "posect",

--- a/api/server.py
+++ b/api/server.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_utils.timing import add_timing_middleware
+
 from lib.json_encoder import MimeJSONEncoder
 from mime_db import MimeDb
 
@@ -114,7 +115,7 @@ async def poses(video_id: UUID, request: Request):
 
 
 @mime_api.get("/shots/{video_id}/")
-async def poses(video_id: UUID, request: Request):
+async def shots(video_id: UUID, request: Request):
     shot_data = await request.app.state.db.get_video_shot_boundaries(video_id)
     return Response(
         content=json.dumps(shot_data, cls=MimeJSONEncoder),

--- a/api/track_video.py
+++ b/api/track_video.py
@@ -7,9 +7,10 @@ import asyncio
 import logging
 from pathlib import Path
 
+from rich.logging import RichHandler
+
 import lib.pose_tracker as pose_tracker
 from mime_db import MimeDb
-from rich.logging import RichHandler
 
 
 async def main() -> None:

--- a/web-ui/src/ambient.d.ts
+++ b/web-ui/src/ambient.d.ts
@@ -59,6 +59,7 @@ type FrameRecord = {
   poseCt: number;
   trackCt: number;
   isShot: number | undefined;
+  movement: number | undefined;
   sim_pose: number | undefined;
   sim_move: number | undefined;
 };

--- a/web-ui/src/ambient.d.ts
+++ b/web-ui/src/ambient.d.ts
@@ -58,8 +58,6 @@ type FrameRecord = {
   avgScore: number;
   poseCt: number;
   trackCt: number;
-  localShot: number | undefined;
-  globalShot: number | undefined;
   isShot: number | undefined;
   sim_pose: number | undefined;
   sim_move: number | undefined;
@@ -67,8 +65,6 @@ type FrameRecord = {
 
 type ShotRecord = {
   frame: number;
-  localShot: number | undefined;
-  globalShot: number | undefined;
   isShot: number | undefined;
 };
 

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -69,7 +69,7 @@
     let i = startFrame;
     framesInRange.forEach((frame: FrameRecord) => {
       while (i < frame.frame) {
-        timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, localShot: 0, globalShot: 0, isShot: 0, sim_pose: 0, sim_move: 0 });
+        timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, isShot: 0, sim_pose: 0, sim_move: 0 });
         i++;
       }
       let frameWithSimilarMatches = frame;
@@ -83,7 +83,7 @@
       i++;
     });
     while (i < endFrame) {
-      timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, localShot: 0, globalShot: 0, isShot: 0, sim_pose: 0, sim_move: 0 });
+      timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, isShot: 0, sim_pose: 0, sim_move: 0 });
       i++;
     }
     return timeSeries;

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -14,7 +14,7 @@
 
   export let data: Array<FrameRecord>;
 
-  const seriesColors = ["#0fba81", "#4f46e5", "magenta", "#f9e07688", "white", "gray", "black", "#FFA50088", "brown",];
+  const seriesColors = ["#0fba81", "#4f46e5", "lime", "magenta", "black", "gray", "orange", "#f9e07688", "#FFA50088", "brown"];
   const formatTickXAsTime = (d: number) => { return new Date(d / $currentVideo.fps * 1000).toISOString().slice(12,19).replace(/^0:/,"");
   }
   const formatTickX = (d: unknown) => d;
@@ -69,7 +69,7 @@
     let i = startFrame;
     framesInRange.forEach((frame: FrameRecord) => {
       while (i < frame.frame) {
-        timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, isShot: 0, sim_pose: 0, sim_move: 0 });
+        timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, isShot: 0, movement: 0, sim_pose: 0, sim_move: 0 });
         i++;
       }
       let frameWithSimilarMatches = frame;
@@ -83,7 +83,7 @@
       i++;
     });
     while (i < endFrame) {
-      timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, isShot: 0, sim_pose: 0, sim_move: 0 });
+      timeSeries.push({ frame: i, avgScore: 0, poseCt: 0, faceCt: 0, trackCt: 0, isShot: 0, movement: 0, sim_pose: 0, sim_move: 0 });
       i++;
     }
     return timeSeries;


### PR DESCRIPTION
Motion within each tracked pose's frame of reference is already calculated over small time slices to build the movelets data, so this update just estimates the amount of motion that's happening within each frame and writes that to the `frame` table in the DB at the end of the `just add-motion` ingestion step. A small amount of new UI code displays this info, when available, as a series on the pose data timeline.