### PR TITLE
"Total Movement" fix

### DIFF
--- a/api/mime_db/_data_loading.py
+++ b/api/mime_db/_data_loading.py
@@ -107,7 +107,7 @@ async def add_frame_movement(
             """
         )
 
-        safe_max = max(1, max_movement)  # Just in case a 0 sneaks in...
+        safe_max = min(1, max_movement)  # Just in case a 0 sneaks in...
 
         for frame in movement_data:
             await conn.execute(

--- a/api/mime_db/_read_only.py
+++ b/api/mime_db/_read_only.py
@@ -55,7 +55,7 @@ async def get_pose_data_by_frame(self, video_id: UUID) -> list:
                 posefaces.facect AS "faceCt",
                 posefaces.avgscore AS "avgScore",
                 CAST(frame.is_shot_boundary AS INT) AS "isShot",
-                frame.total_movement AS "movement"
+                NULLIF(frame.total_movement, 'NaN') AS "movement"
         FROM (SELECT pose.video_id,
                     pose.frame,
                     count(pose.pose_idx) AS "posect",


### PR DESCRIPTION
A bug (I assume?) in the `add_frame_movement` function can result in `NaN` values in the database; these values are not serialized appropriately by python's `json.JSONEncoder` and result in invalid JSON being passed to the front-end (which chokes and dies).

In the first place this PR has PostgreSQL return `NULL`s (which the serializer *can* handle) instead of `NaN`s, fixing the immediate issue and allowing the UI to render (this fix has been applied to the codebase running on the Thelio).  However, there shouldn't be `NaN`s in the first place and I think they're an artefact of the `total_movement` values being calculated incorrectly.  If that seems right to you, please merge this PR and we'll recalculate all the movement data in the database.