### PR TITLE
UI source cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
 
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
   },

--- a/web-ui/.prettierrc.json
+++ b/web-ui/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false,
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+}

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lint": "prettier --check src/"
   },
   "dependencies": {
     "@astrojs/tailwind": "^3.1.3",
@@ -24,6 +25,7 @@
     "@types/d3-scale": "^4.0.4",
     "astro": "^2.10.15",
     "postcss-preset-env": "^9.1.3",
+    "prettier-plugin-svelte": "^3.1.2",
     "svelte-check": "^3.5.1"
   }
 }

--- a/web-ui/pnpm-lock.yaml
+++ b/web-ui/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@astrojs/tailwind':
     specifier: ^3.1.3
@@ -36,6 +40,9 @@ devDependencies:
   postcss-preset-env:
     specifier: ^9.1.3
     version: 9.1.3(postcss@8.4.29)
+  prettier-plugin-svelte:
+    specifier: ^3.1.2
+    version: 3.1.2(prettier@3.1.1)(svelte@3.59.2)
   svelte-check:
     specifier: ^3.5.1
     version: 3.5.1(@babel/core@7.22.17)(postcss@8.4.29)(svelte@3.59.2)
@@ -3494,10 +3501,26 @@ packages:
       sass-formatter: 0.7.8
       synckit: 0.8.5
 
+  /prettier-plugin-svelte@3.1.2(prettier@3.1.1)(svelte@3.59.2):
+    resolution: {integrity: sha512-7xfMZtwgAWHMT0iZc8jN4o65zgbAQ3+O32V6W7pXrqNvKnHnkoyQCGCbKeUyXKZLbYE0YhFRnamfxfkEGxm8qA==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+    dependencies:
+      prettier: 3.1.1
+      svelte: 3.59.2
+    dev: true
+
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}

--- a/web-ui/src/ambient.d.ts
+++ b/web-ui/src/ambient.d.ts
@@ -33,7 +33,7 @@ type PoseRecord = {
   track_id: number | null;
   norm: CocoSkeletonNoConfidence;
   face_bbox: FixedLengthArray<number, 4> | undefined; // copied from FaceRecord
-  face_landmarks: FaceLandmarks | undefined;          // if match is found
+  face_landmarks: FaceLandmarks | undefined; // if match is found
   hidden: boolean | undefined;
   distance?: number;
 };
@@ -53,7 +53,7 @@ type FaceRecord = {
   track_id: number;
   cluster_id: number;
   time: string | undefined;
-}
+};
 
 type FrameRecord = {
   frame: number;

--- a/web-ui/src/lib/poseutils.ts
+++ b/web-ui/src/lib/poseutils.ts
@@ -1,57 +1,60 @@
-  // Not currently used, but worth keeping around for a bit
-  const shiftToOrigin = (keypoints: CocoSkeletonWithConfidence, bbox:FixedLengthArray<number, 4>) => {
-    let newKeypoints: CocoSkeletonWithConfidence = [...keypoints];
+// Not currently used, but worth keeping around for a bit
+const shiftToOrigin = (
+  keypoints: CocoSkeletonWithConfidence,
+  bbox: FixedLengthArray<number, 4>,
+) => {
+  let newKeypoints: CocoSkeletonWithConfidence = [...keypoints];
 
-    for (let x:number = 0; x<keypoints.length; x+=3) {
-      newKeypoints[x] -= bbox[0];
-    }
-    for (let y:number = 1; y<keypoints.length; y+=3) {
-      newKeypoints[y] -= bbox[1];
-    }
-    return newKeypoints;
+  for (let x: number = 0; x < keypoints.length; x += 3) {
+    newKeypoints[x] -= bbox[0];
   }
+  for (let y: number = 1; y < keypoints.length; y += 3) {
+    newKeypoints[y] -= bbox[1];
+  }
+  return newKeypoints;
+};
 
-  export const getNormDims = (keypoints: CocoSkeletonNoConfidence) => {
-    let x_values:Array<number> = [];
-    let y_values:Array<number> = [];
-    for (let i:number = 0; i<keypoints.length; i++) {
-      if (keypoints[i] >= 0) {
-        if (i % 2 == 0) {
-          x_values.push(keypoints[i]);
-        } else {
-          y_values.push(keypoints[i]);
-        }
+export const getNormDims = (keypoints: CocoSkeletonNoConfidence) => {
+  let x_values: Array<number> = [];
+  let y_values: Array<number> = [];
+  for (let i: number = 0; i < keypoints.length; i++) {
+    if (keypoints[i] >= 0) {
+      if (i % 2 == 0) {
+        x_values.push(keypoints[i]);
+      } else {
+        y_values.push(keypoints[i]);
       }
     }
-    let min_x = Math.min(...x_values);
-    let max_x = Math.max(...x_values);
-    let min_y = Math.min(...y_values);
-    let max_y = Math.max(...y_values);
-
-    let width = max_x - min_x;
-    let height = max_y - min_y;
-
-    return [width, height];
   }
+  let min_x = Math.min(...x_values);
+  let max_x = Math.max(...x_values);
+  let min_y = Math.min(...y_values);
+  let max_y = Math.max(...y_values);
 
-  export const getExtent = (keypoints: CocoSkeletonWithConfidence) => {
-    let x_values:Array<number> = [];
-    let y_values:Array<number> = [];
-    for (let i:number = 0; i<keypoints.length; i++) {
-      if ((i % 3 == 0) && (keypoints[i+2] > 0)) {
-        x_values.push(keypoints[i]);        
-      } else if (((i-1) % 3 == 0) && (keypoints[i+1] > 0)) {
-        y_values.push(keypoints[i]);      
-      }
+  let width = max_x - min_x;
+  let height = max_y - min_y;
+
+  return [width, height];
+};
+
+export const getExtent = (keypoints: CocoSkeletonWithConfidence) => {
+  let x_values: Array<number> = [];
+  let y_values: Array<number> = [];
+  for (let i: number = 0; i < keypoints.length; i++) {
+    if (i % 3 == 0 && keypoints[i + 2] > 0) {
+      x_values.push(keypoints[i]);
+    } else if ((i - 1) % 3 == 0 && keypoints[i + 1] > 0) {
+      y_values.push(keypoints[i]);
     }
-
-    let min_x = Math.min(...x_values);
-    let max_x = Math.max(...x_values);
-    let min_y = Math.min(...y_values);
-    let max_y = Math.max(...y_values);
-
-    let width = max_x - min_x;
-    let height = max_y - min_y;
-
-    return [min_x, min_y, width, height];
   }
+
+  let min_x = Math.min(...x_values);
+  let max_x = Math.max(...x_values);
+  let min_y = Math.min(...y_values);
+  let max_y = Math.max(...y_values);
+
+  let width = max_x - min_x;
+  let height = max_y - min_y;
+
+  return [min_x, min_y, width, height];
+};

--- a/web-ui/src/styles/styles.css
+++ b/web-ui/src/styles/styles.css
@@ -8,8 +8,8 @@ body {
 }
 
 :root {
-  --theme-font-family-base: '', sans-serif;
-  --theme-font-family-heading: '', sans-serif;
+  --theme-font-family-base: "", sans-serif;
+  --theme-font-family-heading: "", sans-serif;
 }
 
 div.hide-paginator-label label.paginator-label {

--- a/web-ui/src/svelte/App.svelte
+++ b/web-ui/src/svelte/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TabGroup, Tab } from '@skeletonlabs/skeleton';
+  import { TabGroup, Tab } from "@skeletonlabs/skeleton";
   import { AppShell } from "@skeletonlabs/skeleton";
   import { AppBar } from "@skeletonlabs/skeleton";
 
@@ -7,11 +7,18 @@
   import PoseDataExplorer from "@svelte/PoseDataExplorer.svelte";
   import FacesTimeline from "@svelte/FacesTimeline.svelte";
   import FrameViewer from "@svelte/FrameViewer.svelte";
-  import PosesTimeline from './PosesTimeline.svelte';
+  import PosesTimeline from "./PosesTimeline.svelte";
   import SimilarMovelets from "@svelte/SimilarMovelets.svelte";
   import SimilarPoses from "@svelte/SimilarPoses.svelte";
   import Icon from "@svelte/Icon.svelte";
-  import { currentVideo, currentFrame, currentPose, similarPoseFrames, similarMoveletFrames, currentMoveletPose } from "@svelte/stores";
+  import {
+    currentVideo,
+    currentFrame,
+    currentPose,
+    similarPoseFrames,
+    similarMoveletFrames,
+    currentMoveletPose,
+  } from "@svelte/stores";
   import { tooltip } from "@svelte/actions/tooltip";
 
   import { baseTitle } from "@/site-metadata.json";
@@ -40,19 +47,35 @@
           <Icon name="file-analytics" height="24" width="24" />
         </a>
 
-        <a href={`${base}jupyter/tree/notebooks`} use:tooltip={"Jupyter"} target="_blank">
+        <a
+          href={`${base}jupyter/tree/notebooks`}
+          use:tooltip={"Jupyter"}
+          target="_blank"
+        >
           <Icon name="jupyter" height="24" width="24" />
         </a>
 
-        <a href={`${base}api/docs`} use:tooltip={"Swagger API docs"} target="_blank">
+        <a
+          href={`${base}api/docs`}
+          use:tooltip={"Swagger API docs"}
+          target="_blank"
+        >
           <Icon name="book-2" height="24" width="24" />
         </a>
 
-        <a href={`${base}api/redoc`} use:tooltip={"ReDoc API docs"} target="_blank">
+        <a
+          href={`${base}api/redoc`}
+          use:tooltip={"ReDoc API docs"}
+          target="_blank"
+        >
           <Icon name="notebook" height="24" width="24" />
         </a>
 
-        <a href="https://github.com/sul-cidr/mime" use:tooltip={"GitHub"} target="_blank">
+        <a
+          href="https://github.com/sul-cidr/mime"
+          use:tooltip={"GitHub"}
+          target="_blank"
+        >
           <Icon name="github" height="24" width="24" />
         </a>
       </svelte:fragment>
@@ -60,13 +83,32 @@
   </svelte:fragment>
 
   <section class="m-8 flex flex-col gap-10">
-
     <TabGroup>
       <Tab bind:group={tabSet} name="tab1" value={0}>Performances</Tab>
-      <Tab bind:group={tabSet} name="tab2" value={1} class={$currentVideo ? "opacity-100" : "opacity-50"}>Timeline</Tab>
-      <Tab bind:group={tabSet} name="tab3" value={2} class={$currentVideo ? "opacity-100" : "opacity-50"}>Poses</Tab>
-      <Tab bind:group={tabSet} name="tab4" value={3} class={$currentVideo ? "opacity-100" : "opacity-50"}>Faces</Tab>
-      <Tab bind:group={tabSet} name="tab5" value={4} class={$currentVideo ? "opacity-100" : "opacity-50"}>Explorer</Tab>
+      <Tab
+        bind:group={tabSet}
+        name="tab2"
+        value={1}
+        class={$currentVideo ? "opacity-100" : "opacity-50"}>Timeline</Tab
+      >
+      <Tab
+        bind:group={tabSet}
+        name="tab3"
+        value={2}
+        class={$currentVideo ? "opacity-100" : "opacity-50"}>Poses</Tab
+      >
+      <Tab
+        bind:group={tabSet}
+        name="tab4"
+        value={3}
+        class={$currentVideo ? "opacity-100" : "opacity-50"}>Faces</Tab
+      >
+      <Tab
+        bind:group={tabSet}
+        name="tab5"
+        value={4}
+        class={$currentVideo ? "opacity-100" : "opacity-50"}>Explorer</Tab
+      >
 
       <svelte:fragment slot="panel">
         {#if tabSet === 0}
@@ -88,7 +130,10 @@
         {:else if tabSet === 2}
           {#if $currentVideo}
             <h2>{$currentVideo.video_name}</h2>
-            <PosesTimeline videoId={$currentVideo.id} videoName={$currentVideo.video_name} />
+            <PosesTimeline
+              videoId={$currentVideo.id}
+              videoName={$currentVideo.video_name}
+            />
             {#if $currentFrame}
               <FrameViewer />
             {/if}
@@ -101,7 +146,7 @@
               <FrameViewer />
             {/if}
           {/if}
-          {:else if tabSet === 4}
+        {:else if tabSet === 4}
           {#if $currentVideo}
             <h2>{$currentVideo.video_name}</h2>
             <div>{@html poseplotFrame}</div>
@@ -109,7 +154,5 @@
         {/if}
       </svelte:fragment>
     </TabGroup>
-
   </section>
-
 </AppShell>

--- a/web-ui/src/svelte/FacesTimeline.svelte
+++ b/web-ui/src/svelte/FacesTimeline.svelte
@@ -16,7 +16,7 @@
   let facesData: Array<FaceRecord> | undefined;
   let shotsData: Array<ShotRecord> | undefined;
 
-  let maxCluster:number = 0;
+  let maxCluster: number = 0;
 
   const xKey = "frame";
   const yKey = "cluster_id";
@@ -24,10 +24,14 @@
   const dotRadius = 4;
   const plotPadding = 2;
 
-  const formatTickXAsTime = (d: number) => { return new Date(d / $currentVideo.fps * 1000).toISOString().slice(12,19).replace(/^0:/,""); }
+  const formatTickXAsTime = (d: number) => {
+    return new Date((d / $currentVideo.fps) * 1000)
+      .toISOString()
+      .slice(12, 19)
+      .replace(/^0:/, "");
+  };
   let xTicks: Array<number>;
   let yTicks: Array<number>;
-
 
   const updateFacesData = (data: Array<FaceRecord>) => {
     if (data) {
@@ -39,15 +43,15 @@
         face[xKey] = +face[xKey];
         face[yKey] = +face[yKey];
       });
-      yTicks = [...Array(maxCluster+1).keys()];
+      yTicks = [...Array(maxCluster + 1).keys()];
     }
-  }
+  };
 
   const updateShotsData = (data: Array<ShotRecord>) => {
     if (data) {
       shotsData = data;
     }
-  }
+  };
 
   const formatTitle = (d: string) => `Frame ${d}`;
 
@@ -63,16 +67,12 @@
 
   $: {
     facesData = undefined;
-    getClusteredFacesData(videoId).then((data) =>
-      updateFacesData(data),
-    );
+    getClusteredFacesData(videoId).then((data) => updateFacesData(data));
   }
 
   $: {
     shotsData = undefined;
-    getShotBoundaries(videoId).then((data) =>
-      updateShotsData(data),
-    );
+    getShotBoundaries(videoId).then((data) => updateShotsData(data));
   }
 
   $: {
@@ -81,9 +81,8 @@
       (_, i) => i * 10000,
     );
   }
-
 </script>
-  
+
 {#if facesData}
   <div class="chart-container">
     <LayerCake
@@ -103,22 +102,31 @@
           snapTicks={true}
           tickMarks={true}
         />
-        <AxisY
-          ticks={yTicks}
-        />
+        <AxisY ticks={yTicks} />
         {#if shotsData}
           {#each shotsData as shot}
-            <ProgressLine frameno={shot.frame} yKey="cluster_id" yDomain={[0, maxCluster]} lineType="shot-line"/>
+            <ProgressLine
+              frameno={shot.frame}
+              yKey="cluster_id"
+              yDomain={[0, maxCluster]}
+              lineType="shot-line"
+            />
           {/each}
         {/if}
-        <ScatterSvg
-          r={dotRadius}
-          fill={'rgba(0, 0, 204, 0.75)'}
+        <ScatterSvg r={dotRadius} fill={"rgba(0, 0, 204, 0.75)"} />
+        <ProgressLine
+          frameno={$currentFrame || 0}
+          yKey="cluster_id"
+          yDomain={[0, maxCluster]}
         />
-        <ProgressLine frameno={$currentFrame || 0} yKey="cluster_id" yDomain={[0, maxCluster]} />
       </Svg>
       <Html>
-        <SharedTooltip formatTitle={formatTitle} dataset={facesData} searchRadius={"10"} highlightKey={"cluster_id"}/>
+        <SharedTooltip
+          {formatTitle}
+          dataset={facesData}
+          searchRadius={"10"}
+          highlightKey={"cluster_id"}
+        />
       </Html>
     </LayerCake>
   </div>
@@ -135,4 +143,3 @@
     padding-right: 10px;
   }
 </style>
-  

--- a/web-ui/src/svelte/FrameDetails.svelte
+++ b/web-ui/src/svelte/FrameDetails.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { currentVideo, currentFrame, currentPose, currentMoveletPose } from "@svelte/stores";
+  import {
+    currentVideo,
+    currentFrame,
+    currentPose,
+    currentMoveletPose,
+  } from "@svelte/stores";
   import { formatSeconds } from "@utils";
   import Icon from "@svelte/Icon.svelte";
 
@@ -7,7 +12,6 @@
   export let trackCt: number;
   export let faceCt: number;
   export let hoveredPoseIdx: number | undefined;
-
 </script>
 
 <div class="card variant-ghost-secondary p-4 w-full">
@@ -34,7 +38,10 @@
         on:mouseover={() => (hoveredPoseIdx = i)}
         on:mouseout={() => (hoveredPoseIdx = undefined)}
       >
-        Pose #{i + 1} | Confidence: {pose.score} {#if pose.track_id !== null} | Track {pose.track_id} {/if }
+        Pose #{i + 1} | Confidence: {pose.score}
+        {#if pose.track_id !== null}
+          | Track {pose.track_id}
+        {/if}
         <div class="flex align-stretch gap-2">
           <button
             class="button px-2 variant-filled"

--- a/web-ui/src/svelte/FrameDisplay.svelte
+++ b/web-ui/src/svelte/FrameDisplay.svelte
@@ -13,7 +13,6 @@
   export let displayWidthPx = 640;
 
   const scaleFactor = displayWidthPx / frameWidth;
-
 </script>
 
 <div>
@@ -35,7 +34,11 @@
         {#each poses as poseData}
           {#if !poseData.hidden}
             <Canvas zIndex={1}>
-              <Pose poseData={poseData.keypoints} faceData={poseData.face_landmarks} {scaleFactor} />
+              <Pose
+                poseData={poseData.keypoints}
+                faceData={poseData.face_landmarks}
+                {scaleFactor}
+              />
             </Canvas>
           {/if}
         {/each}

--- a/web-ui/src/svelte/FrameViewer.svelte
+++ b/web-ui/src/svelte/FrameViewer.svelte
@@ -20,9 +20,8 @@
       let trackCount = 0;
       if (data.length) {
         data.forEach((pr: PoseRecord) => {
-          if (pr.track_id !== null)
-            trackCount += 1;
-        })
+          if (pr.track_id !== null) trackCount += 1;
+        });
       }
       trackCt = trackCount;
     }
@@ -42,11 +41,11 @@
               poseData[pi]!.face_bbox = fr.bbox;
               poseData[pi]!.face_landmarks = fr.landmarks;
             }
-          })
-        })
+          });
+        });
       }
     }
-  }
+  };
 
   async function getPoseData(videoId: string, frame: number) {
     if (!frame) {
@@ -131,7 +130,12 @@
   <div class="flex gap-4 p-4 bg-surface-100-800-token">
     {#if poseData}
       <FrameDisplay {showFrame} bind:poses={poseData} bind:hoveredPoseIdx />
-      <FrameDetails bind:poses={poseData} {trackCt} {faceCt} bind:hoveredPoseIdx />
+      <FrameDetails
+        bind:poses={poseData}
+        {trackCt}
+        {faceCt}
+        bind:hoveredPoseIdx
+      />
     {:else}
       Loading pose data... <ProgressBar />
     {/if}

--- a/web-ui/src/svelte/Movelet.svelte
+++ b/web-ui/src/svelte/Movelet.svelte
@@ -10,10 +10,13 @@
 
 <LayerCake>
   <Canvas zIndex={1}>
-    <Pose poseData={moveletData.norm} normalizedPose={true} opacity={.5} />
+    <Pose poseData={moveletData.norm} normalizedPose={true} opacity={0.5} />
   </Canvas>
   <Canvas zIndex={2}>
-    <Pose poseData={moveletData.prev_norm} normalizedPose={true} opacity={.3} />
+    <Pose
+      poseData={moveletData.prev_norm}
+      normalizedPose={true}
+      opacity={0.3}
+    />
   </Canvas>
 </LayerCake>
-  

--- a/web-ui/src/svelte/Pose.svelte
+++ b/web-ui/src/svelte/Pose.svelte
@@ -49,7 +49,13 @@
   // Face coords are right_eye, left_eye, nose, mouth_right, mouth_left
   // Pose will already draw face landmark connectors, so if there's
   // additional face detection data, just draw dots on the points
-  const FACE_COLORS = ["lime", "limegreen", "chartreuse", "lawngreen", "springgreen"]
+  const FACE_COLORS = [
+    "lime",
+    "limegreen",
+    "chartreuse",
+    "lawngreen",
+    "springgreen",
+  ];
 
   export let poseData: CocoSkeletonWithConfidence | CocoSkeletonNoConfidence;
   export let faceData: FaceLandmarks = null;
@@ -72,7 +78,7 @@
 
   const segmentArray = (arr: Array<number>, l = 3) => {
     if (arr == null) {
-      return null
+      return null;
     }
     const _arr = [...arr];
     return [...Array(Math.ceil(arr.length / l))].map((_) => _arr.splice(0, l));
@@ -134,13 +140,20 @@
         const dotRadius = scaleFactor > 0.8 ? 3 : 2;
         facePoints?.forEach(([centerX, centerY], i) => {
           $ctx.beginPath();
-          $ctx.arc(centerX! * normalizationFactor * scaleFactor, centerY! * normalizationFactor * scaleFactor, dotRadius * scaleFactor, 0, 2 * Math.PI, false);
+          $ctx.arc(
+            centerX! * normalizationFactor * scaleFactor,
+            centerY! * normalizationFactor * scaleFactor,
+            dotRadius * scaleFactor,
+            0,
+            2 * Math.PI,
+            false,
+          );
           $ctx.fillStyle = FACE_COLORS[i]!;
           $ctx.fill();
           $ctx.lineWidth = dotRadius;
           $ctx.strokeStyle = FACE_COLORS[i]!;
           $ctx.stroke();
-        })
+        });
       }
     }
   }

--- a/web-ui/src/svelte/PoseDataExplorer.svelte
+++ b/web-ui/src/svelte/PoseDataExplorer.svelte
@@ -24,7 +24,7 @@
     filteredData.forEach((frame) => {
       frame.time = formatSeconds(frame.frame / $currentVideo.fps);
     });
-  }
+  };
 
   $videoId: {
     getPoseData(videoId).then((_data) => updatePoseData(_data));

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
   import { LayerCake, Svg, Html, groupLonger, flatten } from "layercake";
   import { scaleOrdinal } from "d3-scale";
@@ -52,7 +54,8 @@
   let groupedData: Array<Object>;
   let xTicks: Array<number>;
 
-  let brushExtents: Array<number | null> = [null, null];
+  let brushMin: number;
+  let brushMax: number;
   let groupedBrushedData: Array<Object>;
 
   let brushFaded = true;
@@ -170,6 +173,8 @@
     }
   }
 
+  $: maxValue = getMaxValue(data);
+
   $: {
     if (maxValue != 0) {
       groupedData = groupLonger(
@@ -191,11 +196,11 @@
     if (maxValue != 0) {
       const startFrame = Math.max(
         1,
-        Math.ceil($currentVideo.frame_count * (brushExtents[0] || 0)),
+        Math.ceil($currentVideo.frame_count * (brushMin || 0)),
       );
       const endFrame = Math.min(
         $currentVideo.frame_count,
-        Math.ceil($currentVideo.frame_count * (brushExtents[1] || 1)),
+        Math.ceil($currentVideo.frame_count * (brushMax || 1)),
       );
       if (startFrame !== endFrame) {
         groupedBrushedData = groupLonger(
@@ -214,7 +219,6 @@
         );
       }
     }
-    maxValue = getMaxValue(data);
   }
 </script>
 
@@ -283,7 +287,7 @@
       <ProgressLine frameno={$currentFrame || 0} />
     </Svg>
     <Html>
-      <Brush bind:min={brushExtents[0]} bind:max={brushExtents[1]} />
+      <Brush bind:min={brushMin} bind:max={brushMax} />
     </Html>
   </LayerCake>
 </div>

--- a/web-ui/src/svelte/PosesTimeline.svelte
+++ b/web-ui/src/svelte/PosesTimeline.svelte
@@ -17,7 +17,7 @@
   let posesData: Array<MoveletRecord> | undefined;
   let shotsData: Array<ShotRecord> | undefined;
 
-  let maxCluster:number = 0;
+  let maxCluster: number = 0;
 
   const xKey = "start_frame"; // Should cover the full set of frames eventually...
   const yKey = "cluster_id";
@@ -25,7 +25,12 @@
   const dotRadius = 4;
   const plotPadding = 2;
 
-  const formatTickXAsTime = (d: number) => { return new Date(d / $currentVideo.fps * 1000).toISOString().slice(12,19).replace(/^0:/,""); }
+  const formatTickXAsTime = (d: number) => {
+    return new Date((d / $currentVideo.fps) * 1000)
+      .toISOString()
+      .slice(12, 19)
+      .replace(/^0:/, "");
+  };
   let xTicks: Array<number>;
   let yTicks: Array<number>;
 
@@ -36,7 +41,7 @@
     poseImage.src = `${API_BASE}/pose_cluster_image/${videoName}/${d}`;
     poseImage.classList.add("ambassador-pose");
     return poseImage;
-  }
+  };
 
   const updatePosesData = (data: Array<MoveletRecord>) => {
     if (data) {
@@ -46,17 +51,19 @@
         pose[xKey] = +pose[xKey];
         pose[yKey] = +pose[yKey];
         pose.pose_idx = pose.pose_idx += 1;
-        pose.time = formatSeconds(((pose.start_frame + pose.end_frame) / 2) / $currentVideo.fps);
+        pose.time = formatSeconds(
+          (pose.start_frame + pose.end_frame) / 2 / $currentVideo.fps,
+        );
       });
-      yTicks = [...Array(maxCluster+1).keys()];
+      yTicks = [...Array(maxCluster + 1).keys()];
     }
-  }
+  };
 
   const updateShotsData = (data: Array<ShotRecord>) => {
     if (data) {
       shotsData = data;
     }
-  }
+  };
 
   const formatTitle = (d: string) => `Frame ${d}`;
 
@@ -72,16 +79,12 @@
 
   $: {
     posesData = undefined;
-    getClusteredPosesData(videoId).then((data) =>
-      updatePosesData(data),
-    );
+    getClusteredPosesData(videoId).then((data) => updatePosesData(data));
   }
 
   $: {
     shotsData = undefined;
-    getShotBoundaries(videoId).then((data) =>
-      updateShotsData(data),
-    );
+    getShotBoundaries(videoId).then((data) => updateShotsData(data));
   }
 
   $: {
@@ -90,9 +93,8 @@
       (_, i) => i * 10000,
     );
   }
+</script>
 
-  </script>
-    
 {#if posesData}
   <div class="chart-container">
     <LayerCake
@@ -112,31 +114,45 @@
           snapTicks={true}
           tickMarks={true}
         />
-        <AxisY
-          ticks={yTicks}
-        />
+        <AxisY ticks={yTicks} />
         {#if shotsData}
           {#each shotsData as shot}
-            <ProgressLine frameno={shot.frame} xKey="start_frame" yKey="cluster_id" yDomain={[0, maxCluster]} lineType="shot-line"/>
+            <ProgressLine
+              frameno={shot.frame}
+              xKey="start_frame"
+              yKey="cluster_id"
+              yDomain={[0, maxCluster]}
+              lineType="shot-line"
+            />
           {/each}
         {/if}
-        <ScatterSvg
-          r={dotRadius}
-          fill={'rgba(0, 0, 204, 0.75)'}
+        <ScatterSvg r={dotRadius} fill={"rgba(0, 0, 204, 0.75)"} />
+        <ProgressLine
+          frameno={$currentFrame || 0}
+          xKey="start_frame"
+          yKey="cluster_id"
+          yDomain={[0, maxCluster]}
         />
-        <ProgressLine frameno={$currentFrame || 0} xKey="start_frame" yKey="cluster_id" yDomain={[0, maxCluster]} />
       </Svg>
       <Html>
-        <PoseTooltip formatTitle={formatTitle} dataset={posesData} searchRadius={"10"} highlightKey={"cluster_id"}/>
+        <PoseTooltip
+          {formatTitle}
+          dataset={posesData}
+          searchRadius={"10"}
+          highlightKey={"cluster_id"}
+        />
       </Html>
     </LayerCake>
   </div>
   <div>
     <ul>
-      {#each Array(maxCluster+1) as _, index (index)}
+      {#each Array(maxCluster + 1) as _, index (index)}
         <li class="ambassador-box">
           cluster {index}
-          <img src="{`${API_BASE}/pose_cluster_image/${videoName}/${index}`}" class="ambassador-pose-image">
+          <img
+            src={`${API_BASE}/pose_cluster_image/${videoName}/${index}`}
+            class="ambassador-pose-image"
+          />
         </li>
       {/each}
     </ul>
@@ -157,11 +173,10 @@
     display: inline-block;
     list-style-position: inside;
     border: 1px solid black;
-    margin: .75em;
+    margin: 0.75em;
     padding: 5px;
   }
   .ambassador-pose-image {
     width: 100px;
   }
 </style>
-  

--- a/web-ui/src/svelte/SimilarMovelets.svelte
+++ b/web-ui/src/svelte/SimilarMovelets.svelte
@@ -1,162 +1,185 @@
 <script lang="ts">
-    import { Paginator, RadioGroup, RadioItem } from "@skeletonlabs/skeleton";
-    import { LayerCake, Canvas } from "layercake";
-    import Movelet from "@svelte/Movelet.svelte";
-    import { formatSeconds } from "../lib/utils";
-  
-    import { API_BASE } from "@config";
-    import { currentMovelet, currentMoveletPose, currentVideo, similarMoveletFrames } from "@svelte/stores";
-  
-    export let similarityMetric = "cosine";
-    let movelets: Array<MoveletRecord>;
-  
-    const simStep = 5;
-    let simPager = {
-      offset: 0,
-      limit: simStep,
-      size: 50,
-      amounts: [simStep]
-    };
+  import { Paginator, RadioGroup, RadioItem } from "@skeletonlabs/skeleton";
+  import { LayerCake, Canvas } from "layercake";
+  import Movelet from "@svelte/Movelet.svelte";
+  import { formatSeconds } from "../lib/utils";
 
-    const resetMovelets = () => $similarMoveletFrames = {};
-  
-    const updateMoveletData = (data: MoveletRecord[]) => {
-      movelets = data;
-      $similarMoveletFrames = {};
-      movelets.forEach((movelet) => {
-        for (let i = movelet['start_frame']; i <= movelet['end_frame']; i++) {
-            $similarMoveletFrames[i] = 1;
-        }
-      });
-      simPager.size=movelets.length
-    };
+  import { API_BASE } from "@config";
+  import {
+    currentMovelet,
+    currentMoveletPose,
+    currentVideo,
+    similarMoveletFrames,
+  } from "@svelte/stores";
 
-    const updateCurrentMovelet = (data: MoveletRecord) => {
-      $currentMovelet = data;
-    }
-  
-    async function getMoveletData(
-      videoId: number,
-      frame: number,
-      trackIdx: number,
-      similarityMetric: string,
-    ) {
-      const response = await fetch(
-        `${API_BASE}/movelets/similar/${similarityMetric}/${videoId}/${frame}/${trackIdx}`,
-      );
-      return await response.json();
-    }
+  export let similarityMetric = "cosine";
+  let movelets: Array<MoveletRecord>;
 
-    async function getMoveletFromPose(
-      videoId: number,
-      frame: number,
-      trackIdx: number,
-    ) {
-      const response = await fetch(
-        `${API_BASE}/movelets/pose/${videoId}/${frame}/${trackIdx}/`,
-      );
-      return await response.json();
-    }  
-  
-    $: getMoveletData(
-      $currentMoveletPose.video_id,
-      $currentMoveletPose.frame,
-      $currentMoveletPose.track_id,
-      similarityMetric,
-    ).then((data) => updateMoveletData(data));
+  const simStep = 5;
+  let simPager = {
+    offset: 0,
+    limit: simStep,
+    size: 50,
+    amounts: [simStep],
+  };
 
-    $: getMoveletFromPose(
-      $currentMoveletPose.video_id,
-      $currentMoveletPose.frame,
-      $currentMoveletPose.track_id,
-    ).then((data) => updateCurrentMovelet(data));
-  </script>
-  
-  {#if Object.keys($similarMoveletFrames).length}
-    <section
-      class="variant-ghost-secondary px-4 pt-4 pb-8 flex flex-col gap-4 items-center"
-    >
-      <div class="p-1 inline-flex items-center space-x-1 rounded-token">
-        <span><strong>Movelets similarity:</strong></span>
-        <RadioGroup>
-          <RadioItem
-            bind:group={similarityMetric}
-            name="similarity-metric"
-            value="cosine">Cosine</RadioItem
-          >
-          <RadioItem
-            bind:group={similarityMetric}
-            name="similarity-metric"
-            value="euclidean">Euclidean</RadioItem
-          >
-          <RadioItem
-            bind:group={similarityMetric}
-            name="similarity-metric"
-            value="innerproduct">Inner Product</RadioItem
-          >
-        </RadioGroup>
-        <span><strong><button class="btn-sm variant-filled" type="button" on:click={resetMovelets}>X</button></strong></span>
-      </div>
-      {#if movelets}
-        <div class="flex gap-4">
-          <div class="card variant-ghost-tertiary drop-shadow-lg">
-            <header class="p-2">
-              Frames {$currentMovelet.start_frame} - {$currentMovelet.end_frame}, Track: {$currentMovelet.track_id}
-            </header>
-            <div class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]">
-              <LayerCake>
-                <Canvas zIndex={1}>
-                  <Movelet moveletData={$currentMovelet} normalizedPose={true} />
-                  <!-- <Pose poseData={$currentMoveletPose.norm} normalizedPose={true} /> -->
-                </Canvas>
-              </LayerCake>
-            </div>
-            <footer class="p-2">
-              <ul>
-                <li>
-                  Time: {formatSeconds($currentMoveletPose.frame / $currentVideo.fps)}
-                </li>
-              </ul>
-            </footer>
+  const resetMovelets = () => ($similarMoveletFrames = {});
+
+  const updateMoveletData = (data: MoveletRecord[]) => {
+    movelets = data;
+    $similarMoveletFrames = {};
+    movelets.forEach((movelet) => {
+      for (let i = movelet["start_frame"]; i <= movelet["end_frame"]; i++) {
+        $similarMoveletFrames[i] = 1;
+      }
+    });
+    simPager.size = movelets.length;
+  };
+
+  const updateCurrentMovelet = (data: MoveletRecord) => {
+    $currentMovelet = data;
+  };
+
+  async function getMoveletData(
+    videoId: number,
+    frame: number,
+    trackIdx: number,
+    similarityMetric: string,
+  ) {
+    const response = await fetch(
+      `${API_BASE}/movelets/similar/${similarityMetric}/${videoId}/${frame}/${trackIdx}`,
+    );
+    return await response.json();
+  }
+
+  async function getMoveletFromPose(
+    videoId: number,
+    frame: number,
+    trackIdx: number,
+  ) {
+    const response = await fetch(
+      `${API_BASE}/movelets/pose/${videoId}/${frame}/${trackIdx}/`,
+    );
+    return await response.json();
+  }
+
+  $: getMoveletData(
+    $currentMoveletPose.video_id,
+    $currentMoveletPose.frame,
+    $currentMoveletPose.track_id,
+    similarityMetric,
+  ).then((data) => updateMoveletData(data));
+
+  $: getMoveletFromPose(
+    $currentMoveletPose.video_id,
+    $currentMoveletPose.frame,
+    $currentMoveletPose.track_id,
+  ).then((data) => updateCurrentMovelet(data));
+</script>
+
+{#if Object.keys($similarMoveletFrames).length}
+  <section
+    class="variant-ghost-secondary px-4 pt-4 pb-8 flex flex-col gap-4 items-center"
+  >
+    <div class="p-1 inline-flex items-center space-x-1 rounded-token">
+      <span><strong>Movelets similarity:</strong></span>
+      <RadioGroup>
+        <RadioItem
+          bind:group={similarityMetric}
+          name="similarity-metric"
+          value="cosine">Cosine</RadioItem
+        >
+        <RadioItem
+          bind:group={similarityMetric}
+          name="similarity-metric"
+          value="euclidean">Euclidean</RadioItem
+        >
+        <RadioItem
+          bind:group={similarityMetric}
+          name="similarity-metric"
+          value="innerproduct">Inner Product</RadioItem
+        >
+      </RadioGroup>
+      <span
+        ><strong
+          ><button
+            class="btn-sm variant-filled"
+            type="button"
+            on:click={resetMovelets}>X</button
+          ></strong
+        ></span
+      >
+    </div>
+    {#if movelets}
+      <div class="flex gap-4">
+        <div class="card variant-ghost-tertiary drop-shadow-lg">
+          <header class="p-2">
+            Frames {$currentMovelet.start_frame} - {$currentMovelet.end_frame},
+            Track: {$currentMovelet.track_id}
+          </header>
+          <div class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]">
+            <LayerCake>
+              <Canvas zIndex={1}>
+                <Movelet moveletData={$currentMovelet} normalizedPose={true} />
+                <!-- <Pose poseData={$currentMoveletPose.norm} normalizedPose={true} /> -->
+              </Canvas>
+            </LayerCake>
           </div>
-  
-          <span class="divider-vertical !border-l-8 !border-double" />
-  
-          {#each movelets as movelet, m}
-            {#if m >= (simPager.offset * simPager.limit) && m < (simPager.offset * simPager.limit) + simPager.limit}
-              <div class="card drop-shadow-lg">
-                <header class="p-2">
-                  Frames {movelet.start_frame} - {movelet.end_frame}, Track: {movelet.track_id + 1}
-                </header>
-                <div class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]">
-                  <Movelet moveletData={movelet} normalizedPose={true} />
-                </div>
-                <footer class="p-2">
-                  <ul>
-                    <li>Time: {formatSeconds(movelet.start_frame / $currentVideo.fps)}</li>
-                    <li>Distance: {movelet.distance?.toFixed(2)}</li>
-                  </ul>
-                </footer>
+          <footer class="p-2">
+            <ul>
+              <li>
+                Time: {formatSeconds(
+                  $currentMoveletPose.frame / $currentVideo.fps,
+                )}
+              </li>
+            </ul>
+          </footer>
+        </div>
+
+        <span class="divider-vertical !border-l-8 !border-double" />
+
+        {#each movelets as movelet, m}
+          {#if m >= simPager.offset * simPager.limit && m < simPager.offset * simPager.limit + simPager.limit}
+            <div class="card drop-shadow-lg">
+              <header class="p-2">
+                Frames {movelet.start_frame} - {movelet.end_frame}, Track: {movelet.track_id +
+                  1}
+              </header>
+              <div
+                class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]"
+              >
+                <Movelet moveletData={movelet} normalizedPose={true} />
               </div>
-            {/if}
-          {/each}
-        </div>
-        <div class="hide-paginator-label flex items-baseline"><span>Similar movelets</span>
-          <Paginator
-            bind:settings={simPager}
-            showFirstLastButtons="{false}"
-            showPreviousNextButtons="{true}"
-            amountText="Poses"
-          />
-        </div>
-      {/if}
-    </section>
-  {/if}
-  
-  <style>
-    .frame-display {
-      background: radial-gradient(circle at 50% -250%, #333, #111827, #333);
-      box-shadow: inset 0px 0px 30px 0px #666;
-    }
-  </style>
-  
+              <footer class="p-2">
+                <ul>
+                  <li>
+                    Time: {formatSeconds(
+                      movelet.start_frame / $currentVideo.fps,
+                    )}
+                  </li>
+                  <li>Distance: {movelet.distance?.toFixed(2)}</li>
+                </ul>
+              </footer>
+            </div>
+          {/if}
+        {/each}
+      </div>
+      <div class="hide-paginator-label flex items-baseline">
+        <span>Similar movelets</span>
+        <Paginator
+          bind:settings={simPager}
+          showFirstLastButtons={false}
+          showPreviousNextButtons={true}
+          amountText="Poses"
+        />
+      </div>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .frame-display {
+    background: radial-gradient(circle at 50% -250%, #333, #111827, #333);
+    box-shadow: inset 0px 0px 30px 0px #666;
+  }
+</style>

--- a/web-ui/src/svelte/SimilarPoses.svelte
+++ b/web-ui/src/svelte/SimilarPoses.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { Paginator, RadioGroup, RadioItem, SlideToggle } from "@skeletonlabs/skeleton";
+  import {
+    Paginator,
+    RadioGroup,
+    RadioItem,
+    SlideToggle,
+  } from "@skeletonlabs/skeleton";
   import { LayerCake, Canvas, Html } from "layercake";
   import Pose from "@svelte/Pose.svelte";
   import { formatSeconds } from "@utils";
@@ -14,21 +19,21 @@
 
   const simStep = 5;
   let simPager = {
-	  offset: 0,
-	  limit: simStep,
-	  size: 50,
-    amounts: [simStep]
+    offset: 0,
+    limit: simStep,
+    size: 50,
+    amounts: [simStep],
   };
 
-  const resetPoses = () => $similarPoseFrames = {};
+  const resetPoses = () => ($similarPoseFrames = {});
 
   const updatePoseData = (data: Array<PoseRecord>) => {
     poses = data;
     $similarPoseFrames = {};
     poses.forEach((pose) => {
-      $similarPoseFrames[pose['frame']] = 1;
+      $similarPoseFrames[pose["frame"]] = 1;
     });
-    simPager.size=poses.length
+    simPager.size = poses.length;
   };
 
   async function getPoseData(
@@ -77,7 +82,15 @@
       <SlideToggle name="slider-label" bind:checked={showFrame} size="sm">
         Show Image
       </SlideToggle>
-      <span><strong><button class="btn-sm variant-filled" type="button" on:click={resetPoses}>X</button></strong></span>
+      <span
+        ><strong
+          ><button
+            class="btn-sm variant-filled"
+            type="button"
+            on:click={resetPoses}>X</button
+          ></strong
+        ></span
+      >
     </div>
     {#if poses}
       <div class="flex gap-4">
@@ -87,14 +100,21 @@
           </header>
           <div class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]">
             <LayerCake>
-            {#if showFrame}
-              <Html zIndex={0}>
-                <img class="object-contain h-full w-full"
-                src={`${API_BASE}/frame/resize/${$currentPose.video_id}/${$currentPose.frame}/${getExtent($currentPose.keypoints).join(",")}|${getNormDims($currentPose.norm).join(",")}`}
-                alt={`Frame ${$currentPose.frame}, Pose: ${$currentPose.pose_idx + 1}`}
-                />
-              </Html>
-            {/if}
+              {#if showFrame}
+                <Html zIndex={0}>
+                  <img
+                    class="object-contain h-full w-full"
+                    src={`${API_BASE}/frame/resize/${$currentPose.video_id}/${
+                      $currentPose.frame
+                    }/${getExtent($currentPose.keypoints).join(
+                      ",",
+                    )}|${getNormDims($currentPose.norm).join(",")}`}
+                    alt={`Frame ${$currentPose.frame}, Pose: ${
+                      $currentPose.pose_idx + 1
+                    }`}
+                  />
+                </Html>
+              {/if}
               <Canvas zIndex={1}>
                 <Pose poseData={$currentPose.norm} normalizedPose={true} />
               </Canvas>
@@ -112,18 +132,25 @@
         <span class="divider-vertical !border-l-8 !border-double" />
 
         {#each poses as pose, p}
-          {#if p >= (simPager.offset * simPager.limit) && p < (simPager.offset * simPager.limit) + simPager.limit}
+          {#if p >= simPager.offset * simPager.limit && p < simPager.offset * simPager.limit + simPager.limit}
             <div class="card drop-shadow-lg">
               <header class="p-2">
                 Frame {pose.frame}, Pose: {pose.pose_idx + 1}
               </header>
-              <div class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]">
+              <div
+                class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]"
+              >
                 <LayerCake>
                   {#if showFrame}
                     <Html zIndex={0}>
-                      <img class="object-contain h-full w-full"
-                      src={`${API_BASE}/frame/resize/${pose.video_id}/${pose.frame}/${getExtent(pose.keypoints).join(",")}|${getNormDims(pose.norm).join(",")}`}
-                      alt={`Frame ${pose.frame}, Pose: ${pose.pose_idx + 1}`}
+                      <img
+                        class="object-contain h-full w-full"
+                        src={`${API_BASE}/frame/resize/${pose.video_id}/${
+                          pose.frame
+                        }/${getExtent(pose.keypoints).join(",")}|${getNormDims(
+                          pose.norm,
+                        ).join(",")}`}
+                        alt={`Frame ${pose.frame}, Pose: ${pose.pose_idx + 1}`}
                       />
                     </Html>
                   {/if}
@@ -142,11 +169,12 @@
           {/if}
         {/each}
       </div>
-      <div class="hide-paginator-label flex items-baseline"><span>Similar poses</span>
+      <div class="hide-paginator-label flex items-baseline">
+        <span>Similar poses</span>
         <Paginator
           bind:settings={simPager}
-          showFirstLastButtons="{false}"
-          showPreviousNextButtons="{true}"
+          showFirstLastButtons={false}
+          showPreviousNextButtons={true}
           amountText="Poses"
         />
       </div>

--- a/web-ui/src/svelte/VideosTable.svelte
+++ b/web-ui/src/svelte/VideosTable.svelte
@@ -3,7 +3,15 @@
   import { ProgressBar, Table } from "@skeletonlabs/skeleton";
   import type { TableSource } from "@skeletonlabs/skeleton";
 
-  import { videoTableData, currentVideo, similarPoseFrames, similarMoveletFrames, currentPose, currentMovelet, currentMoveletPose } from "@svelte/stores";
+  import {
+    videoTableData,
+    currentVideo,
+    similarPoseFrames,
+    similarMoveletFrames,
+    currentPose,
+    currentMovelet,
+    currentMoveletPose,
+  } from "@svelte/stores";
 
   import { API_BASE } from "@config";
 
@@ -12,7 +20,6 @@
   let videoTableSource: TableSource | void;
 
   async function getVideos() {
-
     if ($videoTableData) return $videoTableData;
 
     const response = await (await fetch(`${API_BASE}/videos/`)).json();
@@ -23,12 +30,24 @@
   const updateVideoData = (): Promise<TableSource | void> => {
     return getVideos()
       .then((data) => ({
-        head: ["", "Name", "Meta", "Length", "Poses", "Poses/Frame", "Faces", "Tracks", "Shots"],
+        head: [
+          "",
+          "Name",
+          "Meta",
+          "Length",
+          "Poses",
+          "Poses/Frame",
+          "Faces",
+          "Tracks",
+          "Shots",
+        ],
         body: data.videos.map((video: VideoRecord) => [
-          (video.video_name === $currentVideo?.video_name ? "⮕" : " "),
+          video.video_name === $currentVideo?.video_name ? "⮕" : " ",
           video.video_name,
           `${video.width}x${video.height}@${video.fps.toFixed(2)}fps`,
-          new Date(video.frame_count / video.fps * 1000).toISOString().slice(11, 19),
+          new Date((video.frame_count / video.fps) * 1000)
+            .toISOString()
+            .slice(11, 19),
           video.pose_ct,
           video.poses_per_frame,
           video.face_ct,
@@ -40,25 +59,28 @@
         // foot: [...],
       }))
       .catch((error) => error);
-    };
+  };
 
   const highlightVideoRow = (video: VideoRecord) => {
     if (video === undefined || document === undefined) return;
 
-    const allTrs = document.querySelectorAll('tr');
-    allTrs.forEach((tr) => { tr.classList.remove("table-row-checked");
-                             const unselectedTd = tr.querySelector('td[tabindex="0"]');
-                             if (unselectedTd) unselectedTd.textContent = " ";  
-                           });
-    const allTds = document.querySelectorAll('td');
-    const selectedTd = Array.from(allTds).find(td => td.textContent === video.video_name);
+    const allTrs = document.querySelectorAll("tr");
+    allTrs.forEach((tr) => {
+      tr.classList.remove("table-row-checked");
+      const unselectedTd = tr.querySelector('td[tabindex="0"]');
+      if (unselectedTd) unselectedTd.textContent = " ";
+    });
+    const allTds = document.querySelectorAll("td");
+    const selectedTd = Array.from(allTds).find(
+      (td) => td.textContent === video.video_name,
+    );
     const selectedTr = selectedTd?.parentElement;
     selectedTr?.classList.add("table-row-checked");
     const bulletTd = selectedTr?.querySelector('td[tabindex="0"]');
     if (bulletTd) {
       bulletTd.textContent = "⮕";
     }
-  }
+  };
 
   const selectVideoHandler = ({ detail: video }: { detail: VideoRecord }) => {
     $currentVideo = video;
@@ -75,7 +97,6 @@
   });
 
   $: highlightVideoRow($currentVideo);
-
 </script>
 
 {#if videoTableSource !== undefined && !(videoTableSource instanceof Error)}

--- a/web-ui/src/svelte/layercake/AxisX.svelte
+++ b/web-ui/src/svelte/layercake/AxisX.svelte
@@ -35,10 +35,10 @@
   $: tickVals = Array.isArray(ticks)
     ? ticks
     : isBandwidth
-    ? $xScale.domain()
-    : typeof ticks === "function"
-    ? ticks($xScale.ticks())
-    : $xScale.ticks(ticks);
+      ? $xScale.domain()
+      : typeof ticks === "function"
+        ? ticks($xScale.ticks())
+        : $xScale.ticks(ticks);
 
   function textAnchor(i) {
     if (snapTicks === true) {

--- a/web-ui/src/svelte/layercake/AxisY.svelte
+++ b/web-ui/src/svelte/layercake/AxisY.svelte
@@ -39,10 +39,10 @@
   $: tickVals = Array.isArray(ticks)
     ? ticks
     : isBandwidth
-    ? $yScale.domain()
-    : typeof ticks === "function"
-    ? ticks($yScale.ticks())
-    : $yScale.ticks(ticks);
+      ? $yScale.domain()
+      : typeof ticks === "function"
+        ? ticks($yScale.ticks())
+        : $yScale.ticks(ticks);
 </script>
 
 <g class="axis y-axis" transform="translate({-$padding.left}, 0)">

--- a/web-ui/src/svelte/layercake/Key.html.svelte
+++ b/web-ui/src/svelte/layercake/Key.html.svelte
@@ -90,7 +90,10 @@
   .name {
     display: inline;
     font-size: 14px;
-    text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff,
+    text-shadow:
+      -1px -1px 0 #fff,
+      1px -1px 0 #fff,
+      -1px 1px 0 #fff,
       1px 1px 0 #fff;
   }
 </style>

--- a/web-ui/src/svelte/layercake/PoseTooltip.html.svelte
+++ b/web-ui/src/svelte/layercake/PoseTooltip.html.svelte
@@ -46,12 +46,12 @@
   const w2 = w / 2;
 
   let showFrame = true;
-  
+
   /* --------------------------------------------
    * Convert results object into a list of key->values,
    * sorting by highest value if doSort is set.
    */
-  function resultArray(result, doSort=false) {
+  function resultArray(result, doSort = false) {
     if (Object.keys(result).length === 0) return [];
     let rows = Object.keys(result)
       .filter((d) => d !== $config.x)
@@ -72,7 +72,10 @@
    * If a highlight key is specified, get its value
    */
   function getHighlightValue(result) {
-    if ((Object.keys(result).length > 0) && (Object.keys(result).includes(highlightKey)))
+    if (
+      Object.keys(result).length > 0 &&
+      Object.keys(result).includes(highlightKey)
+    )
       return result[highlightKey];
     return null;
   }
@@ -88,13 +91,12 @@
     const responseJson = await response.json();
     return responseJson[0];
   }
-    
 </script>
-  
+
 <QuadTree
   dataset={dataset || $data}
-  searchRadius={searchRadius}
-  y = {(highlightKey ? undefined : "x")}
+  {searchRadius}
+  y={highlightKey ? undefined : "x"}
   let:x
   let:y
   let:visible
@@ -110,47 +112,58 @@
       style="
         width:{w}px;
         display: {visible ? 'flex' : 'none'};
-        top:{$yScale(highlightKeyValue === null ? foundArray[0].value : highlightKeyValue) + offset}px;
+        top:{$yScale(
+        highlightKeyValue === null ? foundArray[0].value : highlightKeyValue,
+      ) + offset}px;
         left:{Math.min(Math.max(w2, x), $width - w2)}px;"
     >
-        <div class="tooltip-data">
-          <div class="title">{formatTitle(found[$config.x])}</div>
-          {#each foundArray as row}
-            {#if !hiddenKeys.includes(row.key)}
-              <div class="row">
-                <span class="key">{formatKey(row.key)}:</span>
-                {formatValue(row.value)}
-              </div>
-            {/if}
-          {/each}
-        </div>
-        <div class="tooltip-image aspect-[5/6] py-[30px] px-[10px]">
-          {#await poseFromMatch(found)}
-            <p>Pose data loading...</p>
-          {:then mouseoverPose}
-              <LayerCake>
-                <Html zIndex={0}>
-                  <img class="object-contain h-full w-full"
-                    src={`${API_BASE}/frame/resize/${mouseoverPose.video_id}/${mouseoverPose.frame}/${getExtent(mouseoverPose.keypoints).join(",")}|${getNormDims(mouseoverPose.norm).join(",")}`}
-                    alt={`Frame ${mouseoverPose.frame}, Pose: ${mouseoverPose.pose_idx + 1}`}
-                  />
-                </Html>
-                <Canvas zIndex={1}>
-                  <Pose poseData={mouseoverPose.norm} normalizedPose={true} />
-                </Canvas>
-              </LayerCake>
-          {/await}
-        </div>
+      <div class="tooltip-data">
+        <div class="title">{formatTitle(found[$config.x])}</div>
+        {#each foundArray as row}
+          {#if !hiddenKeys.includes(row.key)}
+            <div class="row">
+              <span class="key">{formatKey(row.key)}:</span>
+              {formatValue(row.value)}
+            </div>
+          {/if}
+        {/each}
+      </div>
+      <div class="tooltip-image aspect-[5/6] py-[30px] px-[10px]">
+        {#await poseFromMatch(found)}
+          <p>Pose data loading...</p>
+        {:then mouseoverPose}
+          <LayerCake>
+            <Html zIndex={0}>
+              <img
+                class="object-contain h-full w-full"
+                src={`${API_BASE}/frame/resize/${mouseoverPose.video_id}/${
+                  mouseoverPose.frame
+                }/${getExtent(mouseoverPose.keypoints).join(",")}|${getNormDims(
+                  mouseoverPose.norm,
+                ).join(",")}`}
+                alt={`Frame ${mouseoverPose.frame}, Pose: ${
+                  mouseoverPose.pose_idx + 1
+                }`}
+              />
+            </Html>
+            <Canvas zIndex={1}>
+              <Pose poseData={mouseoverPose.norm} normalizedPose={true} />
+            </Canvas>
+          </LayerCake>
+        {/await}
+      </div>
     </div>
     {#if searchRadius !== undefined && highlightKey !== undefined}
       <div
         class="circle"
-        style="top:{$yScale(highlightKeyValue)}px;left:{x}px;display: { visible ? 'block' : 'none' };"
+        style="top:{$yScale(highlightKeyValue)}px;left:{x}px;display: {visible
+          ? 'block'
+          : 'none'};"
       ></div>
     {/if}
   {/if}
 </QuadTree>
-  
+
 <style>
   .svelte-tooltip {
     position: absolute;
@@ -175,7 +188,9 @@
   }
   .svelte-tooltip,
   .line {
-    transition: left 250ms ease-out, top 250ms ease-out;
+    transition:
+      left 250ms ease-out,
+      top 250ms ease-out;
   }
   .title {
     font-weight: bold;
@@ -186,7 +201,7 @@
   .circle {
     position: absolute;
     border-radius: 50%;
-    background-color: rgba(171,0, 214);
+    background-color: rgba(171, 0, 214);
     transform: translate(-50%, -50%);
     pointer-events: none;
     width: 10px;
@@ -199,6 +214,4 @@
   .tooltip-image {
     width: 60%;
   }
-
 </style>
-  

--- a/web-ui/src/svelte/layercake/ProgressLine.svelte
+++ b/web-ui/src/svelte/layercake/ProgressLine.svelte
@@ -3,7 +3,7 @@
 	Generates a vertical SVG line of unit length at the given X (frame) position.
  -->
 <script>
-  import { getContext } from 'svelte';
+  import { getContext } from "svelte";
 
   export let frameno = 0;
 
@@ -12,24 +12,31 @@
   export let yDomain = [0, 1];
   export let lineType = "progress-line";
 
-  const { data, xGet, yGet } = getContext('LayerCake');
+  const { data, xGet, yGet } = getContext("LayerCake");
 
   $: path = (frameno) => {
-    return 'M' + $xGet({[xKey]: frameno}) + ',' + $yGet({[yKey]: yDomain[0]}) + ' v-' + ($yGet({[yKey]: yDomain[0]}) - $yGet({[yKey]: yDomain[1]}));
+    return (
+      "M" +
+      $xGet({ [xKey]: frameno }) +
+      "," +
+      $yGet({ [yKey]: yDomain[0] }) +
+      " v-" +
+      ($yGet({ [yKey]: yDomain[0] }) - $yGet({ [yKey]: yDomain[1] }))
+    );
   };
 </script>
 
 <path class={lineType} d={path(frameno)}></path>
 
 <style>
-	.progress-line {
-		stroke: rgb(246, 57, 57);
-		stroke-linecap: square;
-		stroke-width: 2;
-	}
-	.shot-line {
-		stroke: rgb(200, 200, 200);
-		stroke-linecap: square;
-		stroke-width: 1;
-	}
+  .progress-line {
+    stroke: rgb(246, 57, 57);
+    stroke-linecap: square;
+    stroke-width: 2;
+  }
+  .shot-line {
+    stroke: rgb(200, 200, 200);
+    stroke-linecap: square;
+    stroke-width: 1;
+  }
 </style>

--- a/web-ui/src/svelte/layercake/ScatterSvg.svelte
+++ b/web-ui/src/svelte/layercake/ScatterSvg.svelte
@@ -2,35 +2,33 @@
   @component
   Generates an SVG scatter plot. This component can also work if the x- or y-scale is ordinal, i.e. it has a `.bandwidth` method. See the [timeplot chart](https://layercake.graphics/example/Timeplot) for an example.
  -->
- <script>
-    import { getContext } from 'svelte';
-  
-    const { data, xGet, yGet, xScale, yScale } = getContext('LayerCake');
-  
-    /** @type {Number} [r=5] – The circle's radius. */
-    export let r = 5;
-  
-    /** @type {String} [fill='#0cf'] – The circle's fill color. */
-    export let fill = '#0cf';
-  
-    /** @type {String} [stroke='#000'] – The circle's stroke color. */
-    export let stroke = '#000';
-  
-    /** @type {Number} [strokeWidth=0] – The circle's stroke width. */
-    export let strokeWidth = 0;
-  </script>
-  
-  <g class="scatter-group">
-    {#each $data as d}
-      <circle
-        cx={$xGet(d) + ($xScale.bandwidth ? $xScale.bandwidth() / 2 : 0)}
-        cy={$yGet(d) + ($yScale.bandwidth ? $yScale.bandwidth() / 2 : 0)}
-        {r}
-        {fill}
-        {stroke}
-        stroke-width={strokeWidth}
-      />
-    {/each}
-  </g>
-  
-  
+<script>
+  import { getContext } from "svelte";
+
+  const { data, xGet, yGet, xScale, yScale } = getContext("LayerCake");
+
+  /** @type {Number} [r=5] – The circle's radius. */
+  export let r = 5;
+
+  /** @type {String} [fill='#0cf'] – The circle's fill color. */
+  export let fill = "#0cf";
+
+  /** @type {String} [stroke='#000'] – The circle's stroke color. */
+  export let stroke = "#000";
+
+  /** @type {Number} [strokeWidth=0] – The circle's stroke width. */
+  export let strokeWidth = 0;
+</script>
+
+<g class="scatter-group">
+  {#each $data as d}
+    <circle
+      cx={$xGet(d) + ($xScale.bandwidth ? $xScale.bandwidth() / 2 : 0)}
+      cy={$yGet(d) + ($yScale.bandwidth ? $yScale.bandwidth() / 2 : 0)}
+      {r}
+      {fill}
+      {stroke}
+      stroke-width={strokeWidth}
+    />
+  {/each}
+</g>

--- a/web-ui/src/svelte/layercake/SharedTooltip.html.svelte
+++ b/web-ui/src/svelte/layercake/SharedTooltip.html.svelte
@@ -44,7 +44,7 @@
    * Convert results object into a list of key->values,
    * sorting by highest value if doSort is set.
    */
-   function resultArray(result, doSort=false) {
+  function resultArray(result, doSort = false) {
     if (Object.keys(result).length === 0) return [];
     let rows = Object.keys(result)
       .filter((d) => d !== $config.x)
@@ -64,19 +64,20 @@
   /* --------------------------------------------
    * If a highlight key is specified, get its value
    */
-   function getHighlightValue(result) {
-    if ((Object.keys(result).length > 0) && (Object.keys(result).includes(highlightKey)))
+  function getHighlightValue(result) {
+    if (
+      Object.keys(result).length > 0 &&
+      Object.keys(result).includes(highlightKey)
+    )
       return result[highlightKey];
     return null;
   }
-
-
 </script>
 
 <QuadTree
   dataset={dataset || $data}
-  searchRadius={searchRadius}
-  y = {(highlightKey ? undefined : "x")}
+  {searchRadius}
+  y={highlightKey ? undefined : "x"}
   let:x
   let:y
   let:visible
@@ -92,7 +93,9 @@
       style="
         width:{w}px;
         display: {visible ? 'block' : 'none'};
-        top:{$yScale(highlightKeyValue === null ? foundArray[0].value : highlightKeyValue) + offset}px;
+        top:{$yScale(
+        highlightKeyValue === null ? foundArray[0].value : highlightKeyValue,
+      ) + offset}px;
         left:{Math.min(Math.max(w2, x), $width - w2)}px;"
     >
       <div class="title">{formatTitle(found[$config.x])}</div>
@@ -108,7 +111,9 @@
     {#if searchRadius !== undefined && highlightKey !== undefined}
       <div
         class="circle"
-        style="top:{$yScale(highlightKeyValue)}px;left:{x}px;display: { visible ? 'block' : 'none' };"
+        style="top:{$yScale(highlightKeyValue)}px;left:{x}px;display: {visible
+          ? 'block'
+          : 'none'};"
       ></div>
     {/if}
   {/if}
@@ -136,7 +141,9 @@
   }
   .tooltip,
   .line {
-    transition: left 250ms ease-out, top 250ms ease-out;
+    transition:
+      left 250ms ease-out,
+      top 250ms ease-out;
   }
   .title {
     font-weight: bold;
@@ -147,7 +154,7 @@
   .circle {
     position: absolute;
     border-radius: 50%;
-    background-color: rgba(171,0, 214);
+    background-color: rgba(171, 0, 214);
     transform: translate(-50%, -50%);
     pointer-events: none;
     width: 10px;

--- a/web-ui/src/svelte/stores.ts
+++ b/web-ui/src/svelte/stores.ts
@@ -4,8 +4,10 @@ export const currentVideo: Writable<VideoRecord> = writable();
 export const currentFrame: Writable<number | undefined> = writable();
 export const seriesNames: Writable<string[]> = writable([]);
 export const currentPose: Writable<PoseRecord> = writable();
-export const similarPoseFrames: Writable<{[frameno: number]: number}> = writable({});
+export const similarPoseFrames: Writable<{ [frameno: number]: number }> =
+  writable({});
 export const currentMovelet: Writable<MoveletRecord> = writable();
 export const currentMoveletPose: Writable<MoveletPoseRecord> = writable();
-export const similarMoveletFrames: Writable<{[frameno: number]: number}> = writable({});
+export const similarMoveletFrames: Writable<{ [frameno: number]: number }> =
+  writable({});
 export const videoTableData: Writable<JSON> = writable();


### PR DESCRIPTION
The last two commits of this PR reduce the time to load and parse the data for the main chart by up to ~50%, depending and varying greatly on the source video and the machine the UI is running on (since the major component, especially now, is the the time the browser takes to create and render the SVG).  There is more I was hoping to achieve here, but I couldn't get any of my ideas to work how I wanted, so PRing this now and will revisit another time.  It's not as nearly as big an improvement as I was hoping it would be, but it's better than nothing.

PR also includes some front-end code linting (didn't realize `prettier` wasn't set up properly for the UI code, sorry!)/