### PR TITLE
Display correct clusters in PosePlot and ditch launching animation

### DIFF
--- a/api/cluster_and_plot_poses.py
+++ b/api/cluster_and_plot_poses.py
@@ -662,7 +662,6 @@ async def main() -> None:
         if i != -1:
             d[i]["images"].append(idx)
             d[i]["img"] = os.path.basename(all_image_paths[idx])
-            d[i]["avg_img"] = f"{i}.png"
             d[i]["layout"] = "vectors"
     # remove massive clusters
     # deletable = []
@@ -679,6 +678,7 @@ async def main() -> None:
     clusters = sorted(clusters, key=lambda i: len(i["images"]), reverse=True)
     for idx, i in enumerate(clusters):
         i["label"] = f"Cluster {idx + 1}"
+        i["avg_img"] = f"{idx}.png"
     # slice off the first `max_clusters`
     clusters = clusters[: int(args.n_clusters)]
     # save the hotspots to disk and return the path to the saved json

--- a/api/cluster_and_plot_poses.py
+++ b/api/cluster_and_plot_poses.py
@@ -673,12 +673,17 @@ async def main() -> None:
     #         deletable.append(i)
     # for i in deletable:
     #     del d[i]
-    # sort the clusers by size and then label the clusters
-    clusters = d.values()
-    clusters = sorted(clusters, key=lambda i: len(i["images"]), reverse=True)
-    for idx, i in enumerate(clusters):
-        i["label"] = f"Cluster {idx + 1}"
-        i["avg_img"] = f"{idx}.png"
+    # DO NOT sort the clusers by size
+    # Sort the clusters by label, and label them accordingly
+    # clusters = sorted(clusters, key=lambda i: len(i["images"]), reverse=True)
+    clusters = dict(sorted(d.items()))
+    # for idx, i in enumerate(clusters):
+    #     i["label"] = f"Cluster {idx}"
+    #     i["avg_img"] = f"{idx}.png"
+    for i in clusters:
+        clusters[i]["label"] = f"Cluster {i}"
+        clusters[i]["avg_img"] = f"{i}.png"
+    clusters = list(clusters.values())
     # slice off the first `max_clusters`
     clusters = clusters[: int(args.n_clusters)]
     # save the hotspots to disk and return the path to the saved json

--- a/web-extras/poseplot/web/assets/js/tsne.js
+++ b/web-extras/poseplot/web/assets/js/tsne.js
@@ -3906,40 +3906,40 @@ function Welcome() {
   this.progressElem = document.querySelector("#progress");
   this.loaderTextElem = document.querySelector("#loader-text");
   this.loaderSceneElem = document.querySelector("#loader-scene");
-  this.buttonElem = document.querySelector("#enter-button");
-  this.buttonElem.addEventListener("click", this.onButtonClick.bind(this));
+  //this.buttonElem = document.querySelector("#enter-button");
+  //this.buttonElem.addEventListener("click", this.onButtonClick.bind(this));
 }
 
-Welcome.prototype.onButtonClick = function (e) {
-  if (e.target.className.indexOf("active") > -1) {
-    requestAnimationFrame(
-      function () {
-        this.removeLoader(
-          function () {
-            this.startWorld();
-          }.bind(this),
-        );
-      }.bind(this),
-    );
-  }
-};
+// Welcome.prototype.onButtonClick = function (e) {
+//   if (e.target.className.indexOf("active") > -1) {
+//     requestAnimationFrame(
+//       function () {
+//         this.removeLoader(
+//           function () {
+//             this.startWorld();
+//           }.bind(this),
+//         );
+//       }.bind(this),
+//     );
+//   }
+// };
 
 Welcome.prototype.removeLoader = function (onSuccess) {
   var blocks = document.querySelectorAll(".block");
   for (var i = 0; i < blocks.length; i++) {
-    setTimeout(
-      function (i) {
-        blocks[i].style.animation = "exit 300s";
-        setTimeout(
-          function (i) {
+    // setTimeout(
+    //   function (i) {
+    //     blocks[i].style.animation = "exit 300s";
+    //     setTimeout(
+    //       function (i) {
             blocks[i].parentNode.removeChild(blocks[i]);
             if (i == blocks.length - 1) onSuccess();
-          }.bind(this, i),
-          1000,
-        );
-      }.bind(this, i),
-      i * 100,
-    );
+    //       }.bind(this, i),
+    //       1000,
+    //     );
+    //   }.bind(this, i),
+    //   i * 100,
+    // );
   }
   document.querySelector("#progress").style.opacity = 0;
 };
@@ -3957,7 +3957,17 @@ Welcome.prototype.updateProgress = function () {
     data.loadedTextures == data.textureCount &&
     world.heightmap
   ) {
-    this.buttonElem.className += " active";
+    //this.buttonElem.className += " active";
+    console.log("All loaded, starting world");
+    requestAnimationFrame(
+      function () {
+        this.removeLoader(
+          function () {
+            this.startWorld();
+          }.bind(this),
+        );
+      }.bind(this),
+    );
   }
 };
 

--- a/web-extras/poseplot/web/index.html
+++ b/web-extras/poseplot/web/index.html
@@ -453,7 +453,7 @@
           <span id='progress'>0%</span>
         </div>
       </div>
-      <button id='enter-button'>Enter</button>
+      <!-- <button id='enter-button'>Enter</button> -->
     </div>
     <!-- Canvas -->
     <div id='canvas-container'>
@@ -475,7 +475,7 @@
                 <img class='hotspot-action refresh-hotspot' src='assets/images/icons/refresh.svg'>
               <% } %>
               <div class='hotspot-body no-highlight'>
-                <img class='hotspot-image' src='data/thumbs/<%= hotspot.img %>'>
+                <img class='hotspot-image' src='data/pose_cluster_images/<%= hotspot.avg_img %>'>
                 <div class='hotspot-bar-container'>
                   <div class='hotspot-bar-inner'></div>
                 </div>

--- a/web-ui/src/svelte/Pose.svelte
+++ b/web-ui/src/svelte/Pose.svelte
@@ -93,8 +93,8 @@
   }
 
   let segments: FixedLengthArray<
-    FixedLengthArray<number, 2> | FixedLengthArray<number, 3>
-    //,total_coco_coords;
+    FixedLengthArray<number, 2> | FixedLengthArray<number, 3>,
+    total_coco_coords
   >;
 
   import { getContext } from "svelte";

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -28,7 +28,7 @@
     "#0fba81", // green-blue
     "#4f46e5", // blue
     "lime",
-    "f00ff88", // magenta
+    "#ff00ff88", // magenta
     "black",
     "gray",
     "orange",

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -25,16 +25,16 @@
   export let timelineData: Array<FrameRecord>;
 
   const seriesColors = [
-    "#0fba81",
-    "#4f46e5",
+    "#0fba81", // green-blue
+    "#4f46e5", // blue
     "lime",
-    "magenta",
+    "f00ff88", // magenta
     "black",
     "gray",
     "orange",
-    "#f9e07688",
-    "#FFA50088",
-    "brown",
+    "#964B00BB", // brown
+    "#fA8072BB", // salmon
+    "fbceb1", // apricot
   ];
   const formatTickXAsTime = (d: number) => {
     return new Date((d / $currentVideo.fps) * 1000)


### PR DESCRIPTION
These changes make the pose clusters visible in the PosePlot "Exporer" for a video identical to the pose clusters in the "Poses" timeline. Changes to the clustering/UMAP parameters and to the display settings also ensure that the PosePlot layout is more cohesive and easier to see without always having to increase the image/"point" size via the UI.