### PR TITLE
Mini-form for search parameters, reduce response JSON bundles, linting

### DIFF
--- a/api/calculate_pose_interest.py
+++ b/api/calculate_pose_interest.py
@@ -13,8 +13,6 @@ from scipy.spatial.distance import cosine  # , euclidean
 from lib.pose_drawing import draw_normalized_and_unflattened_pose
 from mime_db import MimeDb
 
-DEFAULT_CLUSTERS = 15  # Expected number of pose clusters
-
 
 async def main() -> None:
     """Command-line entry-point."""

--- a/api/mime_db/_read_only.py
+++ b/api/mime_db/_read_only.py
@@ -171,13 +171,11 @@ async def get_nearest_poses(
         "innerproduct": f"({embedding} <#> ({sub_query}) * -1",
     }[metric]
 
-    print("METRIC:", metric, "MAX_DISTANCE", max_distance)
-
     return await self._pool.fetch(
         f"""
         WITH search_results AS(
             SELECT pose.*, {distance} AS distance, frame.shot AS shot, face.cluster_id AS face_cluster_id FROM pose, frame, face
-            WHERE pose.video_id = $1 AND frame.video_id = $1 AND face.video_id = $1 AND face.frame=pose.frame AND face.pose_idx = pose.pose_idx AND pose.frame = frame.frame AND NOT ((pose.frame = $2 AND pose.pose_idx = $3) OR (frame.shot = $4)) ORDER BY distance
+            WHERE pose.video_id = $1 AND frame.video_id = $1 AND face.video_id = $1 AND face.frame = pose.frame AND face.pose_idx = pose.pose_idx AND pose.frame = frame.frame AND NOT ((pose.frame = $2 AND pose.pose_idx = $3) OR frame.shot = $4) ORDER BY distance
             LIMIT $5
         )
         SELECT * from search_results where search_results.distance < {max_distance}
@@ -202,7 +200,14 @@ async def get_movelet_from_pose(
 
 
 async def get_nearest_movelets(
-    self, video_id: UUID, frame: int, track_id: int, metric="cosine", limit=500
+    self,
+    video_id: UUID,
+    frame: int,
+    track_id: int,
+    metric="cosine",
+    max_distance="Infinity",
+    avoid_shot=-1,
+    limit=500,
 ) -> list:
     sub_query = """
         SELECT motion
@@ -219,13 +224,17 @@ async def get_nearest_movelets(
 
     return await self._pool.fetch(
         f"""
-        SELECT *, {distance} AS distance FROM movelet
-        WHERE video_id = $1 AND NOT (start_frame <= $2 AND end_frame >= $2 AND track_id = $3)
-        ORDER BY distance
-        LIMIT $4;
+        WITH search_results AS(
+            SELECT movelet.*, {distance} AS distance, frame.shot AS shot, face.cluster_id AS face_cluster_id FROM movelet, frame, face
+            WHERE movelet.video_id = $1 AND frame.video_id = $1 AND face.video_id = $1 AND face.frame = movelet.start_frame AND face.pose_idx = movelet.pose_idx AND movelet.start_frame = frame.frame AND NOT ((movelet.start_frame <= $2 AND movelet.end_frame >= $2) OR frame.shot = $4 OR (movelet.start_frame = $2 AND movelet.track_id = $3))
+            ORDER BY distance
+            LIMIT $5
+        )
+        SELECT * from search_results where search_results.distance < {max_distance}
         """,
         video_id,
         frame,
         track_id,
+        avoid_shot,
         limit,
     )

--- a/api/mime_db/_read_only.py
+++ b/api/mime_db/_read_only.py
@@ -174,7 +174,7 @@ async def get_nearest_poses(
     return await self._pool.fetch(
         f"""
         WITH search_results AS(
-            SELECT pose.*, {distance} AS distance, frame.shot AS shot, face.cluster_id AS face_cluster_id FROM pose, frame, face
+            SELECT pose.video_id, pose.frame, pose.pose_idx, pose.norm, pose.keypoints, {distance} AS distance, frame.shot AS shot, face.cluster_id AS face_cluster_id FROM pose, frame, face
             WHERE pose.video_id = $1 AND frame.video_id = $1 AND face.video_id = $1 AND face.frame = pose.frame AND face.pose_idx = pose.pose_idx AND pose.frame = frame.frame AND NOT ((pose.frame = $2 AND pose.pose_idx = $3) OR frame.shot = $4) ORDER BY distance
             LIMIT $5
         )
@@ -225,7 +225,7 @@ async def get_nearest_movelets(
     return await self._pool.fetch(
         f"""
         WITH search_results AS(
-            SELECT movelet.*, {distance} AS distance, frame.shot AS shot, face.cluster_id AS face_cluster_id FROM movelet, frame, face
+            SELECT movelet.video_id, movelet.start_frame, movelet.end_frame, movelet.pose_idx, movelet.track_id, movelet.norm, movelet.prev_norm, {distance} AS distance, frame.shot AS shot, face.cluster_id AS face_cluster_id FROM movelet, frame, face
             WHERE movelet.video_id = $1 AND frame.video_id = $1 AND face.video_id = $1 AND face.frame = movelet.start_frame AND face.pose_idx = movelet.pose_idx AND movelet.start_frame = frame.frame AND NOT ((movelet.start_frame <= $2 AND movelet.end_frame >= $2) OR frame.shot = $4 OR (movelet.start_frame = $2 AND movelet.track_id = $3))
             ORDER BY distance
             LIMIT $5

--- a/api/server.py
+++ b/api/server.py
@@ -21,9 +21,6 @@ load_dotenv()
 VIDEO_SRC_FOLDER = os.getenv("VIDEO_SRC_FOLDER")
 CACHE_FOLDER = os.getenv("CACHE_FOLDER")
 
-MAX_COSINE_DISTANCE = 0.05
-MAX_EUCLIDEAN_DISTANCE = 37
-
 try:
     assert VIDEO_SRC_FOLDER
 except AssertionError:
@@ -121,7 +118,7 @@ async def get_frame_region_resized(
 
 
 @mime_api.get("/pose_cluster_image/{video_name}/{cluster_id}/")
-async def get_pose_cluster_image(video_name: str, cluster_id: int, request: Request):
+async def get_pose_cluster_image(video_name: str, cluster_id: int):
     image_path = f"/app/pose_cluster_images/{video_name}/{cluster_id}.png"
     img = iio.imread(image_path)
     return Response(
@@ -131,7 +128,7 @@ async def get_pose_cluster_image(video_name: str, cluster_id: int, request: Requ
 
 
 @mime_api.get("/face_cluster_image/{video_name}/{cluster_id}/")
-async def get_face_cluster_image(video_name: str, cluster_id: int, request: Request):
+async def get_face_cluster_image(video_name: str, cluster_id: int):
     image_path = f"/app/face_cluster_images/{video_name}/{cluster_id}.png"
     img = iio.imread(image_path)
     return Response(
@@ -166,7 +163,7 @@ async def face(video_id: UUID, frameno: int, track_id: int, request: Request):
 async def poses(video_id: UUID, request: Request):
     frame_data = Path(CACHE_FOLDER, str(video_id), "pose_data_by_frame.json")
     if frame_data.exists():
-        with frame_data.open("r") as _fh:
+        with frame_data.open("r", encoding="utf-8") as _fh:
             frame_data = _fh.read()
     else:
         frame_data = await request.app.state.db.get_pose_data_by_frame(video_id)

--- a/web-ui/src/ambient.d.ts
+++ b/web-ui/src/ambient.d.ts
@@ -93,5 +93,6 @@ type MoveletRecord = {
   hidden: boolean | undefined;
   distance?: number;
   cluster_id: number;
+  face_cluster_id: number | null;
   time: string | undefined;
 };

--- a/web-ui/src/ambient.d.ts
+++ b/web-ui/src/ambient.d.ts
@@ -4,8 +4,10 @@ type FixedLengthArray<
   R extends readonly T[] = [],
 > = R["length"] extends N ? R : Tuple<T, N, readonly [T, ...R]>;
 
-type CocoSkeletonWithConfidence = FixedLengthArray<number, 51>;
-type CocoSkeletonNoConfidence = FixedLengthArray<number, 34>;
+type Coco13SkeletonWithConfidence = FixedLengthArray<number, 39>;
+type Coco13SkeletonNoConfidence = FixedLengthArray<number, 26>;
+type Coco17SkeletonWithConfidence = FixedLengthArray<number, 51>;
+type Coco17SkeletonNoConfidence = FixedLengthArray<number, 34>;
 type SmplSkeletonWithConfidence = FixedLengthArray<number, 135>;
 type SmplSkeletonNoConfidence = FixedLengthArray<number, 90>;
 type FaceLandmarks = FixedLengthArray<number, 10>;
@@ -29,11 +31,12 @@ type PoseRecord = {
   video_id: number;
   frame: number;
   pose_idx: number;
-  keypointsopp: CocoSkeletonWithConfidence;
+  keypoints: Coco13SkeletonNoConfidence;
+  keypointsopp: Coco17SkeletonWithConfidence;
   bbox: FixedLengthArray<number, 4>; // bbox format for PifPaf is x0, y0, width, height
   score: number;
   track_id: number | null;
-  norm: CocoSkeletonNoConfidence;
+  norm: Coco13SkeletonNoConfidence;
   face_bbox: FixedLengthArray<number, 4> | undefined; // copied from FaceRecord
   face_landmarks: FaceLandmarks | undefined; // if match is found
   keypoints4dh: SmplSkeletonWithConfidence;
@@ -88,8 +91,8 @@ type MoveletRecord = {
   start_frame: number;
   end_frame: number;
   pose_idx: number;
-  prev_norm: CocoSkeletonNoConfidence;
-  norm: CocoSkeletonNoConfidence;
+  prev_norm: Coco13SkeletonNoConfidence;
+  norm: Coco13SkeletonNoConfidence;
   hidden: boolean | undefined;
   distance?: number;
   cluster_id: number;

--- a/web-ui/src/ambient.d.ts
+++ b/web-ui/src/ambient.d.ts
@@ -10,6 +10,12 @@ type Coco17SkeletonWithConfidence = FixedLengthArray<number, 51>;
 type Coco17SkeletonNoConfidence = FixedLengthArray<number, 34>;
 type SmplSkeletonWithConfidence = FixedLengthArray<number, 135>;
 type SmplSkeletonNoConfidence = FixedLengthArray<number, 90>;
+type CocoSkeletonWithConfidence =
+  | Coco13SkeletonWithConfidence
+  | Coco17SkeletonWithConfidence;
+type CocoSkeletonNoConfidence =
+  | Coco13SkeletonNoConfidence
+  | Coco17SkeletonNoConfidence;
 type FaceLandmarks = FixedLengthArray<number, 10>;
 type FaceEmbedding = FixedLengthArray<number, 4096>;
 
@@ -47,10 +53,6 @@ type PoseRecord = {
   face_cluster_id: number | null;
   pose_interest: number | 0; // this is actually the avg for all poses in the frame :-/
 };
-
-interface MoveletPoseRecord extends PoseRecord {
-  track_id: number;
-}
 
 type FaceRecord = {
   video_id: number;

--- a/web-ui/src/lib/poseutils.ts
+++ b/web-ui/src/lib/poseutils.ts
@@ -1,18 +1,18 @@
 // Not currently used, but worth keeping around for a bit
-const shiftToOrigin = (
-  keypoints: CocoSkeletonWithConfidence,
-  bbox: FixedLengthArray<number, 4>,
-) => {
-  let newKeypoints: CocoSkeletonWithConfidence = [...keypoints];
+// const shiftToOrigin = (
+//   keypoints: CocoSkeletonWithConfidence,
+//   bbox: FixedLengthArray<number, 4>,
+// ) => {
+//   let newKeypoints: CocoSkeletonWithConfidence = [...keypoints];
 
-  for (let x: number = 0; x < keypoints.length; x += 3) {
-    newKeypoints[x] -= bbox[0];
-  }
-  for (let y: number = 1; y < keypoints.length; y += 3) {
-    newKeypoints[y] -= bbox[1];
-  }
-  return newKeypoints;
-};
+//   for (let x: number = 0; x < keypoints.length; x += 3) {
+//     newKeypoints[x] -= bbox[0];
+//   }
+//   for (let y: number = 1; y < keypoints.length; y += 3) {
+//     newKeypoints[y] -= bbox[1];
+//   }
+//   return newKeypoints;
+// };
 
 export const getNormDims = (keypoints: CocoSkeletonNoConfidence) => {
   let x_values: Array<number> = [];

--- a/web-ui/src/svelte/App.svelte
+++ b/web-ui/src/svelte/App.svelte
@@ -28,7 +28,7 @@
 
   let poseplotFrame = "";
 
-  $: $currentVideo, ($currentFrame = undefined);
+  $: $currentVideo, ($currentFrame = null);
   $: poseplotFrame = `<iframe src="/poseplot/${$currentVideo?.video_name}/index.html" width="100%" height="1200px" title="Pose Cluster Explorer" />`;
 </script>
 

--- a/web-ui/src/svelte/FacesTimeline.svelte
+++ b/web-ui/src/svelte/FacesTimeline.svelte
@@ -139,6 +139,7 @@
         <li class="ambassador-box">
           cluster {index}
           <img
+            alt={`Representative blended face image for cluster ${index}`}
             src={`${API_BASE}/face_cluster_image/${videoName}/${index}/`}
             class="ambassador-image"
           />

--- a/web-ui/src/svelte/FrameDetails.svelte
+++ b/web-ui/src/svelte/FrameDetails.svelte
@@ -4,7 +4,7 @@
     currentFrame,
     currentPose,
     currentMoveletPose,
-    maxDistances,
+    searchThresholds,
   } from "@svelte/stores";
   import { formatSeconds } from "@utils";
   import Icon from "@svelte/Icon.svelte";
@@ -35,15 +35,30 @@
       <dd>{(interest * 100).toFixed(2)}%</dd>
     </dl>
 
-    <div class="grid w-1/3 gap-2 p-4">
-      <h4>Max search distances</h4>
+    <div class="grid w-1/3 gap-1 p-4">
+      <h4>Search settings</h4>
+      <div class="flex justify-between">
+        Total Results (1-10000)
+        <label>
+          <input
+            type="number"
+            name="total-results"
+            bind:value={$searchThresholds["total_results"]}
+            size="5"
+            min="1"
+            max="10000"
+            step="10"
+          />
+        </label>
+      </div>
+      <h5>Max search distances</h5>
       <div class="flex justify-between">
         Cosine (.01-.1)
         <label>
           <input
             type="number"
             name="max-cosine-distance"
-            bind:value={$maxDistances["cosine"]}
+            bind:value={$searchThresholds["cosine"]}
             size="4"
             min=".01"
             max=".1"
@@ -57,7 +72,7 @@
           <input
             type="number"
             name="max-euclidean-distance"
-            bind:value={$maxDistances["euclidean"]}
+            bind:value={$searchThresholds["euclidean"]}
             size="4"
             min="1"
             max="100"
@@ -66,12 +81,12 @@
         </label>
       </div>
       <div class="flex justify-between">
-        View-invariant (.01-.1)
+        View Invariant (.01-.1)
         <label>
           <input
             type="number"
-            name="max-invarian-distance"
-            bind:value={$maxDistances["view_invariant"]}
+            name="max-invariant-distance"
+            bind:value={$searchThresholds["view_invariant"]}
             size="4"
             min=".01"
             max=".1"

--- a/web-ui/src/svelte/FrameDetails.svelte
+++ b/web-ui/src/svelte/FrameDetails.svelte
@@ -18,8 +18,8 @@
 
   const updateSearchThresholds = (event) => {
     const input = event.target.form.querySelectorAll("input");
-    input.forEach((item) => {
-      $searchThresholds[item.name] = item.value;
+    input.forEach((item: HTMLInputElement) => {
+      $searchThresholds[item.name] = parseFloat(item.value);
     });
   };
 </script>
@@ -105,7 +105,7 @@
         <button
           type="button"
           class="btn-sm px-2 variant-ghost"
-          on:click|preventDefault={updateSearchThresholds}>Apply</button
+          on:click={updateSearchThresholds}>Apply</button
         >
       </form>
     </div>

--- a/web-ui/src/svelte/FrameDetails.svelte
+++ b/web-ui/src/svelte/FrameDetails.svelte
@@ -4,6 +4,7 @@
     currentFrame,
     currentPose,
     currentMoveletPose,
+    maxDistances,
   } from "@svelte/stores";
   import { formatSeconds } from "@utils";
   import Icon from "@svelte/Icon.svelte";
@@ -16,71 +17,121 @@
   export let interest: number | 0;
 </script>
 
-<div class="card variant-ghost-secondary p-4 w-full">
+<div class="card variant-ghost-secondary w-full">
   <header class="card-header font-bold">
     <h3>Details for frame #{$currentFrame}</h3>
   </header>
-  <dl class="grid grid-cols-2 gap-2 p-4 [&>dt]:font-bold">
-    <dt>#Tracked Poses:</dt>
-    <dd>{trackCt}</dd>
-    <dt>#Detected Faces:</dt>
-    <dd>{faceCt}</dd>
-    <dt>Time:</dt>
-    <dd>{formatSeconds(($currentFrame || 0) / $currentVideo.fps)}</dd>
-    <dt>Shot:</dt>
-    <dd>{shot}</dd>
-    <dt>Interest:</dt>
-    <dd>{(interest * 100).toFixed(2)}%</dd>
-  </dl>
+  <div class="flex">
+    <dl class="grid grid-cols-2 gap-2 p-4 [&>dt]:font-bold w-2/3">
+      <dt>#Tracked Poses:</dt>
+      <dd>{trackCt}</dd>
+      <dt>#Detected Faces:</dt>
+      <dd>{faceCt}</dd>
+      <dt>Time:</dt>
+      <dd>{formatSeconds(($currentFrame || 0) / $currentVideo.fps)}</dd>
+      <dt>Shot:</dt>
+      <dd>{shot}</dd>
+      <dt>Interest:</dt>
+      <dd>{(interest * 100).toFixed(2)}%</dd>
+    </dl>
 
-  <ul>
-    {#each poses as pose, i}
-      <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-      <li
-        class="px-4 py-1 flex items-center gap-2 justify-between cursor-pointer"
-        class:variant-ghost={hoveredPoseIdx === i}
-        on:mouseover={() => (hoveredPoseIdx = i)}
-        on:mouseout={() => (hoveredPoseIdx = undefined)}
-      >
-        Pose #{i + 1} | Confidence: {pose.score.toFixed(3)}
-        {#if pose.track_id !== null}
-          | Track {pose.track_id}
-        {/if}
-        <div class="flex align-stretch gap-2">
-          <button
-            class="button px-2 variant-filled"
-            on:click={() => {
-              $currentPose = pose;
-            }}
-          >
-            sim pose
-          </button>
+    <div class="grid w-1/3 gap-2 p-4">
+      <h4>Max search distances</h4>
+      <div class="flex justify-between">
+        Cosine (.01-.1)
+        <label>
+          <input
+            type="number"
+            name="max-cosine-distance"
+            bind:value={$maxDistances["cosine"]}
+            size="4"
+            min=".01"
+            max=".1"
+            step=".01"
+          />
+        </label>
+      </div>
+      <div class="flex justify-between">
+        Euclidean (1-100)
+        <label>
+          <input
+            type="number"
+            name="max-euclidean-distance"
+            bind:value={$maxDistances["euclidean"]}
+            size="4"
+            min="1"
+            max="100"
+            step="1"
+          />
+        </label>
+      </div>
+      <div class="flex justify-between">
+        View-invariant (.01-.1)
+        <label>
+          <input
+            type="number"
+            name="max-invarian-distance"
+            bind:value={$maxDistances["view_invariant"]}
+            size="4"
+            min=".01"
+            max=".1"
+            step=".01"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-4 w-full">
+    <ul>
+      {#each poses as pose, i}
+        <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+        <li
+          class="px-4 py-1 flex items-center gap-2 justify-between cursor-pointer"
+          class:variant-ghost={hoveredPoseIdx === i}
+          on:mouseover={() => (hoveredPoseIdx = i)}
+          on:mouseout={() => (hoveredPoseIdx = undefined)}
+        >
+          Pose #{i + 1} | Confidence: {pose.score.toFixed(3)}
           {#if pose.track_id !== null}
+            | Track {pose.track_id}
+          {/if}
+          <div class="flex align-stretch gap-2">
             <button
               class="button px-2 variant-filled"
               on:click={() => {
-                $currentMoveletPose = pose;
+                $currentPose = pose;
               }}
             >
-              sim movelet
+              sim pose
             </button>
-          {/if}
-          <button
-            class="btn p-2"
-            class:variant-filled={!pose.hidden}
-            class:variant-ghost-primary={pose.hidden}
-            on:click={() => {
-              pose.hidden = !pose.hidden;
-            }}
-          >
-            {#if pose.hidden}
-              <Icon name="eye" />
-            {:else}
-              <Icon name="eye-off" />
+            {#if pose.track_id !== null}
+              <button
+                class="button px-2 variant-filled"
+                on:click={() => {
+                  $currentMoveletPose = pose;
+                }}
+              >
+                sim movelet
+              </button>
             {/if}
-          </button>
-        </div>
-      </li>
-    {/each}
-  </ul>
+            <button
+              class="btn p-2"
+              class:variant-filled={!pose.hidden}
+              class:variant-ghost-primary={pose.hidden}
+              on:click={() => {
+                pose.hidden = !pose.hidden;
+              }}
+            >
+              {#if pose.hidden}
+                <Icon name="eye" />
+              {:else}
+                <Icon name="eye-off" />
+              {/if}
+            </button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  </div>
 </div>

--- a/web-ui/src/svelte/FrameDetails.svelte
+++ b/web-ui/src/svelte/FrameDetails.svelte
@@ -15,6 +15,13 @@
   export let hoveredPoseIdx: number | undefined;
   export let shot: number | 0;
   export let interest: number | 0;
+
+  const updateSearchThresholds = (event) => {
+    const input = event.target.form.querySelectorAll("input");
+    input.forEach((item) => {
+      $searchThresholds[item.name] = item.value;
+    });
+  };
 </script>
 
 <div class="card variant-ghost-secondary w-full">
@@ -35,65 +42,72 @@
       <dd>{(interest * 100).toFixed(2)}%</dd>
     </dl>
 
-    <div class="grid w-1/3 gap-1 p-4">
+    <div class="grid w-1/3 gap-1 p-4 search-settings">
       <h4>Search settings</h4>
-      <div class="flex justify-between">
-        Total Results (1-10000)
-        <label>
-          <input
-            type="number"
-            name="total-results"
-            bind:value={$searchThresholds["total_results"]}
-            size="5"
-            min="1"
-            max="10000"
-            step="10"
-          />
-        </label>
-      </div>
-      <h5>Max search distances</h5>
-      <div class="flex justify-between">
-        Cosine (.01-.1)
-        <label>
-          <input
-            type="number"
-            name="max-cosine-distance"
-            bind:value={$searchThresholds["cosine"]}
-            size="4"
-            min=".01"
-            max=".1"
-            step=".01"
-          />
-        </label>
-      </div>
-      <div class="flex justify-between">
-        Euclidean (1-100)
-        <label>
-          <input
-            type="number"
-            name="max-euclidean-distance"
-            bind:value={$searchThresholds["euclidean"]}
-            size="4"
-            min="1"
-            max="100"
-            step="1"
-          />
-        </label>
-      </div>
-      <div class="flex justify-between">
-        View Invariant (.01-.1)
-        <label>
-          <input
-            type="number"
-            name="max-invariant-distance"
-            bind:value={$searchThresholds["view_invariant"]}
-            size="4"
-            min=".01"
-            max=".1"
-            step=".01"
-          />
-        </label>
-      </div>
+      <form>
+        <div class="flex justify-between search-options">
+          Max matches [1-10000]
+          <label>
+            <input
+              type="number"
+              name="total_results"
+              value={$searchThresholds["total_results"]}
+              size="5"
+              min="1"
+              max="10000"
+              step="10"
+            />
+          </label>
+        </div>
+        <p>Max distance thresholds:</p>
+        <div class="flex justify-between search-options">
+          Cosine [.01-.1]
+          <label>
+            <input
+              type="number"
+              name="cosine"
+              value={$searchThresholds["cosine"]}
+              size="4"
+              min=".01"
+              max=".1"
+              step=".01"
+            />
+          </label>
+        </div>
+        <div class="flex justify-between search-options">
+          Euclidean [1-100]
+          <label>
+            <input
+              type="number"
+              name="euclidean"
+              value={$searchThresholds["euclidean"]}
+              size="4"
+              min="1"
+              max="100"
+              step="1"
+            />
+          </label>
+        </div>
+        <div class="flex justify-between search-options">
+          View Invariant [.01-.1]
+          <label>
+            <input
+              type="number"
+              name="view_invariant"
+              value={$searchThresholds["view_invariant"]}
+              size="4"
+              min=".01"
+              max=".1"
+              step=".01"
+            />
+          </label>
+        </div>
+        <button
+          type="button"
+          class="btn-sm px-2 variant-ghost"
+          on:click|preventDefault={updateSearchThresholds}>Apply</button
+        >
+      </form>
     </div>
   </div>
 
@@ -150,3 +164,16 @@
     </ul>
   </div>
 </div>
+
+<style>
+  .search-settings {
+    border: 1px solid black;
+    margin-right: 1em;
+  }
+  .search-options {
+    font-weight: bold;
+  }
+  .search-options label {
+    font-weight: normal;
+  }
+</style>

--- a/web-ui/src/svelte/FrameDisplay.svelte
+++ b/web-ui/src/svelte/FrameDisplay.svelte
@@ -67,7 +67,6 @@
                 fill="none"
                 stroke-width="1"
                 class:selected={hoveredPoseIdx === i}
-                on:click={() => console.log(`bbox ${i}`)}
                 on:mouseover={() => (hoveredPoseIdx = i)}
                 on:mouseout={() => (hoveredPoseIdx = undefined)}
                 pointer-events="visible"
@@ -83,9 +82,10 @@
                   fill="none"
                   stroke-width="1"
                   class:selected={hoveredPoseIdx === i}
-                  on:click={() => console.log(`bbox ${i}`)}
                   on:mouseover={() => (hoveredPoseIdx = i)}
+                  on:focus={() => (hoveredPoseIdx = i)}
                   on:mouseout={() => (hoveredPoseIdx = undefined)}
+                  on:blur={() => (hoveredPoseIdx = undefined)}
                   pointer-events="visible"
                   style="cursor: pointer"
                 />

--- a/web-ui/src/svelte/Movelet.svelte
+++ b/web-ui/src/svelte/Movelet.svelte
@@ -3,9 +3,6 @@
   import Pose from "@svelte/Pose.svelte";
 
   export let moveletData: MoveletRecord;
-
-  export let scaleFactor = 1;
-  export let normalizedPose = true; // Movelets are always normalized
 </script>
 
 <LayerCake>

--- a/web-ui/src/svelte/PoseDataExplorer.svelte
+++ b/web-ui/src/svelte/PoseDataExplorer.svelte
@@ -6,7 +6,7 @@
 
   import PosesByFrameChart from "@svelte/PosesByFrameChart.svelte";
   import PoseDataFilters from "@/src/svelte/PoseDataFilters.svelte";
-  import { currentFrame, currentVideo } from "@svelte/stores";
+  import { currentVideo } from "@svelte/stores";
 
   export let videoId: string;
   let data: Array<FrameRecord> | undefined;

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -51,18 +51,18 @@
 
   let hiddenSeries: Array<string> = ["avgScore"];
 
-  let groupedData: Array<Object>;
+  let groupedData: Array<any>;
   let xTicks: Array<number>;
 
   let brushMin: number;
   let brushMax: number;
-  let groupedBrushedData: Array<Object>;
+  let groupedBrushedData: Array<any>;
 
   let brushFaded = true;
 
   let maxValue: number = 0;
 
-  let framesArray: Array<FrameRecord>;
+  let framesArray: Array<any>;
 
   /* Series whose values are always normalized between 0 and 1 in the DB (e.g.,
    * movement and avg pose confidence score) can be scaled to between 0 and the
@@ -107,7 +107,7 @@
     similarMoveletFrames: { [frameno: number]: number },
     startFrame = 1,
     endFrame = $currentVideo.frame_count,
-  ): Array<FrameRecord> => {
+  ) => {
     // fill with zero values for unrepresented frames
     const framesInRange = data
       .filter(
@@ -119,7 +119,7 @@
       );
     const timeSeries = [];
     let i = startFrame;
-    framesInRange.forEach((frame: FrameRecord) => {
+    framesInRange.forEach((frame: Record<string, any>) => {
       while (i < frame.frame) {
         timeSeries.push({
           frame: i,
@@ -135,7 +135,7 @@
         });
         i++;
       }
-      let thisFrame = frame;
+      let thisFrame: Record<string, any> = frame;
       // XXX Using maxValue in this way leads to nonsensical "Similar:" values
       // in the tooltips for frames with matching poses. Either the tooltip
       // code should be customized to hide these, or we shouldn't use this
@@ -143,7 +143,7 @@
       thisFrame["sim_pose"] = i in similarPoseFrames ? maxValue : 0;
       thisFrame["sim_move"] = i in similarMoveletFrames ? maxValue : 0;
       if (!normalizedSeriesAlreadyScaled) {
-        seriesToFit.forEach((series: string) => {
+        seriesToFit.forEach((series) => {
           thisFrame[series] = scaleToFit(frame[series]);
         });
       }
@@ -198,8 +198,6 @@
       $seriesNames.splice($seriesNames.indexOf("sim_move", 1));
     }
   }
-
-  const bob = 1;
 
   $: maxValue = getMaxValue(timelineData);
 

--- a/web-ui/src/svelte/PosesByFrameChart.svelte
+++ b/web-ui/src/svelte/PosesByFrameChart.svelte
@@ -49,7 +49,7 @@
     (d) => !["frame", "time"].includes(d),
   );
 
-  let hiddenSeries: Array<string> = [];
+  let hiddenSeries: Array<string> = ["avgScore"];
 
   let groupedData: Array<Object>;
   let xTicks: Array<number>;

--- a/web-ui/src/svelte/PosesTimeline.svelte
+++ b/web-ui/src/svelte/PosesTimeline.svelte
@@ -36,12 +36,12 @@
 
   // Unsuccessful attempt to display each cluster's "ambassador" pose image as
   // a y-axis tick to the left of the plot.
-  const formatPoseTick = (d: number) => {
-    const poseImage = new Image();
-    poseImage.src = `${API_BASE}/pose_cluster_image/${videoName}/${d}`;
-    poseImage.classList.add("ambassador-pose");
-    return poseImage;
-  };
+  // const formatPoseTick = (d: number) => {
+  //   const poseImage = new Image();
+  //   poseImage.src = `${API_BASE}/pose_cluster_image/${videoName}/${d}`;
+  //   poseImage.classList.add("ambassador-pose");
+  //   return poseImage;
+  // };
 
   const updatePosesData = (data: Array<MoveletRecord>) => {
     if (data) {
@@ -151,6 +151,7 @@
         <li class="ambassador-box">
           cluster {index}
           <img
+            alt={`Representative average pose armature for cluster ${index}`}
             src={`${API_BASE}/pose_cluster_image/${videoName}/${index}/`}
             class="ambassador-image"
           />

--- a/web-ui/src/svelte/SimilarMovelets.svelte
+++ b/web-ui/src/svelte/SimilarMovelets.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { Paginator, RadioGroup, RadioItem } from "@skeletonlabs/skeleton";
+  import {
+    Paginator,
+    RadioGroup,
+    RadioItem,
+    SlideToggle,
+  } from "@skeletonlabs/skeleton";
   import { LayerCake, Canvas } from "layercake";
   import Movelet from "@svelte/Movelet.svelte";
   import { formatSeconds } from "../lib/utils";
@@ -11,13 +16,15 @@
     currentMoveletPose,
     currentVideo,
     similarMoveletFrames,
+    searchThresholds,
   } from "@svelte/stores";
-
+  let avoidShotInResults: boolean = false;
   export let similarityMetric = "cosine";
   let movelets: Array<MoveletRecord>;
 
   const simStep = 5;
   let simPager = {
+    page: 0,
     offset: 0,
     limit: simStep,
     size: 50,
@@ -38,7 +45,16 @@
         $similarMoveletFrames[i] = 1;
       }
     });
-    simPager.size = movelets.length;
+
+    // This is necessary to make the pager reset reactively
+    simPager = {
+      page: 0,
+      offset: 0,
+      limit: simStep,
+      size: movelets.length,
+      amounts: [simStep],
+    };
+    simPager = simPager;
   };
 
   const updateCurrentMovelet = (data: MoveletRecord) => {
@@ -50,11 +66,17 @@
   async function getMoveletData(
     thisMoveletPose: MoveletPoseRecord,
     similarityMetric: string,
+    searchThresholds,
+    avoidShot: boolean,
   ) {
     if (thisMoveletPose === null) return [];
-    const response = await fetch(
-      `${API_BASE}/movelets/similar/${similarityMetric}/${thisMoveletPose.video_id}/${thisMoveletPose.frame}/${thisMoveletPose.track_id}/`,
-    );
+    const response = avoidShot
+      ? await fetch(
+          `${API_BASE}/movelets/similar/${searchThresholds["total_results"]}/${similarityMetric}|${searchThresholds[similarityMetric]}/${thisMoveletPose.video_id}/${thisMoveletPose.frame}/${thisMoveletPose.track_id}/${thisMoveletPose.shot}/`,
+        )
+      : await fetch(
+          `${API_BASE}/movelets/similar/${searchThresholds["total_results"]}/${similarityMetric}|${searchThresholds[similarityMetric]}/${thisMoveletPose.video_id}/${thisMoveletPose.frame}/${thisMoveletPose.track_id}/`,
+        );
     return await response.json();
   }
 
@@ -66,16 +88,19 @@
     return await response.json();
   }
 
-  $: getMoveletData($currentMoveletPose, similarityMetric).then((data) =>
-    updateMoveletData(data),
-  );
+  $: getMoveletData(
+    $currentMoveletPose,
+    similarityMetric,
+    $searchThresholds,
+    avoidShotInResults,
+  ).then((data) => updateMoveletData(data));
 
   $: getMoveletFromPose($currentMoveletPose).then((data) =>
     updateCurrentMovelet(data),
   );
 </script>
 
-{#if Object.keys($similarMoveletFrames).length}
+{#if $currentMovelet}
   <section
     class="variant-ghost-secondary px-4 pt-4 pb-8 flex flex-col gap-4 items-center"
   >
@@ -92,11 +117,11 @@
           name="similarity-metric"
           value="euclidean">Euclidean</RadioItem
         >
-        <RadioItem
+        <!-- <RadioItem
           bind:group={similarityMetric}
           name="similarity-metric"
           value="innerproduct">Inner Product</RadioItem
-        >
+        > -->
       </RadioGroup>
       <span
         ><strong
@@ -110,7 +135,7 @@
     </div>
     {#if movelets}
       <div class="flex gap-4">
-        <div class="card variant-ghost-tertiary drop-shadow-lg">
+        <div class="card stretch-vert variant-ghost-tertiary drop-shadow-lg">
           <header class="p-2">
             Frames {$currentMovelet.start_frame} - {$currentMovelet.end_frame},
             Track: {$currentMovelet.track_id}
@@ -127,10 +152,24 @@
             <ul>
               <li>
                 Time: {formatSeconds(
-                  $currentMoveletPose.frame / $currentVideo.fps,
+                  $currentMovelet.start_frame / $currentVideo.fps,
                 )}
               </li>
+              <li>
+                Face group: {$currentMoveletPose.face_cluster_id}
+              </li>
             </ul>
+            <span
+              ><strong
+                ><button
+                  class="btn-sm variant-filled"
+                  type="button"
+                  value={$currentMovelet.start_frame}
+                  on:click={goToFrame}
+                  >Go to frame {$currentMovelet.start_frame}</button
+                ></strong
+              ></span
+            >
           </footer>
         </div>
 
@@ -138,7 +177,7 @@
 
         {#each movelets as movelet, m}
           {#if m >= simPager.offset * simPager.limit && m < simPager.offset * simPager.limit + simPager.limit}
-            <div class="card drop-shadow-lg">
+            <div class="card stretch-vert drop-shadow-lg">
               <header class="p-2">
                 Frames {movelet.start_frame} - {movelet.end_frame}, Track: {movelet.track_id}
               </header>
@@ -155,6 +194,9 @@
                     )}
                   </li>
                   <li>Distance: {movelet.distance?.toFixed(4)}</li>
+                  <li>
+                    Face group: {movelet.face_cluster_id}
+                  </li>
                 </ul>
                 <span
                   ><strong
@@ -172,14 +214,23 @@
           {/if}
         {/each}
       </div>
-      <div class="hide-paginator-label flex items-baseline">
-        <span>Similar movelets</span>
-        <Paginator
-          bind:settings={simPager}
-          showFirstLastButtons={false}
-          showPreviousNextButtons={true}
-          amountText="Poses"
-        />
+      <div class="flex items-center space-x-5">
+        <SlideToggle
+          name="avoid-shot-toggle"
+          bind:checked={avoidShotInResults}
+          size="sm"
+        >
+          Exclude current shot
+        </SlideToggle>
+        <div class="hide-paginator-label flex items-baseline">
+          <span>Similar movelets</span>
+          <Paginator
+            bind:settings={simPager}
+            showFirstLastButtons={false}
+            showPreviousNextButtons={true}
+            amountText="Poses"
+          />
+        </div>
       </div>
     {/if}
   </section>
@@ -189,5 +240,8 @@
   .frame-display {
     background: radial-gradient(circle at 50% -250%, #333, #111827, #333);
     box-shadow: inset 0px 0px 30px 0px #666;
+  }
+  .stretch-vert {
+    display: inline-grid;
   }
 </style>

--- a/web-ui/src/svelte/SimilarMovelets.svelte
+++ b/web-ui/src/svelte/SimilarMovelets.svelte
@@ -64,9 +64,9 @@
   const goToFrame = (e: any) => ($currentFrame = e.originalTarget.value);
 
   async function getMoveletData(
-    thisMoveletPose: MoveletPoseRecord,
+    thisMoveletPose: PoseRecord | null,
     similarityMetric: string,
-    searchThresholds,
+    searchThresholds: { [id: string]: number },
     avoidShot: boolean,
   ) {
     if (thisMoveletPose === null) return [];
@@ -80,7 +80,7 @@
     return await response.json();
   }
 
-  async function getMoveletFromPose(thisMoveletPose: MoveletPoseRecord) {
+  async function getMoveletFromPose(thisMoveletPose: PoseRecord | null) {
     if (thisMoveletPose === null) return null;
     const response = await fetch(
       `${API_BASE}/movelets/pose/${thisMoveletPose.video_id}/${thisMoveletPose.frame}/${thisMoveletPose.track_id}/`,
@@ -143,7 +143,7 @@
           <div class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]">
             <LayerCake>
               <Canvas zIndex={1}>
-                <Movelet moveletData={$currentMovelet} normalizedPose={true} />
+                <Movelet moveletData={$currentMovelet} />
                 <!-- <Pose poseData={$currentMoveletPose.norm} normalizedPose={true} /> -->
               </Canvas>
             </LayerCake>
@@ -156,7 +156,7 @@
                 )}
               </li>
               <li>
-                Face group: {$currentMoveletPose.face_cluster_id}
+                Face group: {$currentMoveletPose?.face_cluster_id}
               </li>
             </ul>
             <span
@@ -184,7 +184,7 @@
               <div
                 class="w-full aspect-[5/6] frame-display py-[30px] px-[10px]"
               >
-                <Movelet moveletData={movelet} normalizedPose={true} />
+                <Movelet moveletData={movelet} />
               </div>
               <footer class="p-2">
                 <ul>

--- a/web-ui/src/svelte/SimilarPoses.svelte
+++ b/web-ui/src/svelte/SimilarPoses.svelte
@@ -59,9 +59,9 @@
   };
 
   async function getPoseData(
-    thisPose: PoseRecord,
+    thisPose: PoseRecord | null,
     similarityMetric: string,
-    searchThresholds,
+    searchThresholds: { [id: string]: number },
     avoidShot: boolean,
   ) {
     if (thisPose === null) return [];

--- a/web-ui/src/svelte/SimilarPoses.svelte
+++ b/web-ui/src/svelte/SimilarPoses.svelte
@@ -16,7 +16,7 @@
     currentPose,
     currentVideo,
     similarPoseFrames,
-    maxDistances,
+    searchThresholds,
   } from "@svelte/stores";
 
   let avoidShotInResults: boolean = false;
@@ -61,17 +61,17 @@
   async function getPoseData(
     thisPose: PoseRecord,
     similarityMetric: string,
-    maxDistances,
+    searchThresholds,
     avoidShot: boolean,
   ) {
     if (thisPose === null) return [];
 
     const response = avoidShot
       ? await fetch(
-          `${API_BASE}/poses/similar/${similarityMetric}|${maxDistances[similarityMetric]}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/${thisPose.shot}/`,
+          `${API_BASE}/poses/similar/${searchThresholds["total_results"]}/${similarityMetric}|${searchThresholds[similarityMetric]}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/${thisPose.shot}/`,
         )
       : await fetch(
-          `${API_BASE}/poses/similar/${similarityMetric}|${maxDistances[similarityMetric]}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/`,
+          `${API_BASE}/poses/similar/${searchThresholds["total_results"]}/${similarityMetric}|${searchThresholds[similarityMetric]}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/`,
         );
     return await response.json();
   }
@@ -79,7 +79,7 @@
   $: getPoseData(
     $currentPose,
     similarityMetric,
-    $maxDistances,
+    $searchThresholds,
     avoidShotInResults,
   ).then((data) => updatePoseData(data));
 </script>

--- a/web-ui/src/svelte/SimilarPoses.svelte
+++ b/web-ui/src/svelte/SimilarPoses.svelte
@@ -16,6 +16,7 @@
     currentPose,
     currentVideo,
     similarPoseFrames,
+    maxDistances,
   } from "@svelte/stores";
 
   let avoidShotInResults: boolean = false;
@@ -25,6 +26,7 @@
 
   const simStep = 5;
   let simPager = {
+    page: 0,
     offset: 0,
     limit: simStep,
     size: 50,
@@ -44,31 +46,45 @@
     poses.forEach((pose) => {
       $similarPoseFrames[pose["frame"]] = 1;
     });
-    simPager.size = poses.length;
+
+    // This is necessary to make the pager reset reactively
+    simPager = {
+      page: 0,
+      offset: 0,
+      limit: simStep,
+      size: poses.length,
+      amounts: [simStep],
+    };
+    simPager = simPager;
   };
 
   async function getPoseData(
     thisPose: PoseRecord,
     similarityMetric: string,
+    maxDistances,
     avoidShot: boolean,
   ) {
     if (thisPose === null) return [];
+
     const response = avoidShot
       ? await fetch(
-          `${API_BASE}/poses/similar/${similarityMetric}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/${thisPose.shot}/`,
+          `${API_BASE}/poses/similar/${similarityMetric}|${maxDistances[similarityMetric]}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/${thisPose.shot}/`,
         )
       : await fetch(
-          `${API_BASE}/poses/similar/${similarityMetric}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/`,
+          `${API_BASE}/poses/similar/${similarityMetric}|${maxDistances[similarityMetric]}/${thisPose.video_id}/${thisPose.frame}/${thisPose.pose_idx}/`,
         );
     return await response.json();
   }
 
-  $: getPoseData($currentPose, similarityMetric, avoidShotInResults).then(
-    (data) => updatePoseData(data),
-  );
+  $: getPoseData(
+    $currentPose,
+    similarityMetric,
+    $maxDistances,
+    avoidShotInResults,
+  ).then((data) => updatePoseData(data));
 </script>
 
-{#if Object.keys($similarPoseFrames).length}
+{#if $currentPose}
   <section
     class="variant-ghost-secondary px-4 pt-4 pb-8 flex flex-col gap-4 items-center"
   >
@@ -86,10 +102,15 @@
             name="similarity-metric"
             value="euclidean">Euclidean</RadioItem
           >
+          <!-- <RadioItem
+            bind:group={similarityMetric}
+            name="similarity-metric"
+            value="innerproduct">Inner Product</RadioItem
+          > -->
           <RadioItem
             bind:group={similarityMetric}
             name="similarity-metric"
-            value="poem_embedding">View Invariant</RadioItem
+            value="view_invariant">View Invariant</RadioItem
           >
         </RadioGroup>
       </div>
@@ -125,7 +146,7 @@
     </div>
     {#if poses}
       <div class="flex gap-4">
-        <div class="card variant-ghost-tertiary drop-shadow-lg">
+        <div class="card stretch-vert variant-ghost-tertiary drop-shadow-lg">
           <header class="p-2">
             Frame {$currentPose.frame}, Pose: {$currentPose.pose_idx + 1}
           </header>
@@ -179,7 +200,7 @@
 
         {#each poses as pose, p}
           {#if p >= simPager.offset * simPager.limit && p < simPager.offset * simPager.limit + simPager.limit}
-            <div class="card drop-shadow-lg">
+            <div class="card stretch-vert drop-shadow-lg">
               <header class="p-2">
                 Frame {pose.frame}, Pose: {pose.pose_idx + 1}
               </header>
@@ -256,5 +277,8 @@
   .frame-display {
     background: radial-gradient(circle at 50% -250%, #333, #111827, #333);
     box-shadow: inset 0px 0px 30px 0px #666;
+  }
+  .stretch-vert {
+    display: inline-grid;
   }
 </style>

--- a/web-ui/src/svelte/SimilarPoses.svelte
+++ b/web-ui/src/svelte/SimilarPoses.svelte
@@ -158,7 +158,7 @@
                     class="object-contain h-full w-full"
                     src={`${API_BASE}/frame/resize/${$currentPose.video_id}/${
                       $currentPose.frame
-                    }/${getExtent($currentPose.keypointsopp).join(
+                    }/${getExtent($currentPose.keypoints).join(
                       ",",
                     )}|${getNormDims($currentPose.norm).join(",")}/`}
                     alt={`Frame ${$currentPose.frame}, Pose: ${
@@ -214,9 +214,9 @@
                         class="object-contain h-full w-full"
                         src={`${API_BASE}/frame/resize/${pose.video_id}/${
                           pose.frame
-                        }/${getExtent(pose.keypointsopp).join(
-                          ",",
-                        )}|${getNormDims(pose.norm).join(",")}/`}
+                        }/${getExtent(pose.keypoints).join(",")}|${getNormDims(
+                          pose.norm,
+                        ).join(",")}/`}
                         alt={`Frame ${pose.frame}, Pose: ${pose.pose_idx + 1}`}
                       />
                     </Html>

--- a/web-ui/src/svelte/stores.ts
+++ b/web-ui/src/svelte/stores.ts
@@ -11,5 +11,5 @@ export const currentMoveletPose: Writable<MoveletPoseRecord> = writable();
 export const similarMoveletFrames: Writable<{ [frameno: number]: number }> =
   writable({});
 export const videoTableData: Writable<JSON> = writable();
-export const maxDistances: Writable<{ [metric: string]: number }> =
-  writable({"cosine": .05, "euclidean": 37, "view_invariant": .1});
+export const searchThresholds: Writable<{ [metric: string]: number }> =
+  writable({"cosine": .05, "euclidean": 37, "view_invariant": .1, "total_results": 500});

--- a/web-ui/src/svelte/stores.ts
+++ b/web-ui/src/svelte/stores.ts
@@ -1,15 +1,21 @@
 import { Writable, writable } from "svelte/store";
 
 export const currentVideo: Writable<VideoRecord> = writable();
-export const currentFrame: Writable<number | undefined> = writable();
+export const currentFrame: Writable<number | null> = writable();
 export const seriesNames: Writable<string[]> = writable([]);
-export const currentPose: Writable<PoseRecord> = writable();
+export const currentPose: Writable<PoseRecord | null> = writable();
 export const similarPoseFrames: Writable<{ [frameno: number]: number }> =
   writable({});
-export const currentMovelet: Writable<MoveletRecord> = writable();
-export const currentMoveletPose: Writable<MoveletPoseRecord> = writable();
+export const currentMovelet: Writable<MoveletRecord | null> = writable();
+export const currentMoveletPose: Writable<PoseRecord | null> =
+  writable();
 export const similarMoveletFrames: Writable<{ [frameno: number]: number }> =
   writable({});
 export const videoTableData: Writable<JSON> = writable();
 export const searchThresholds: Writable<{ [metric: string]: number }> =
-  writable({"cosine": .05, "euclidean": 37, "view_invariant": .1, "total_results": 500});
+  writable({
+    cosine: 0.05,
+    euclidean: 37,
+    view_invariant: 0.1,
+    total_results: 500,
+  });

--- a/web-ui/src/svelte/stores.ts
+++ b/web-ui/src/svelte/stores.ts
@@ -11,3 +11,5 @@ export const currentMoveletPose: Writable<MoveletPoseRecord> = writable();
 export const similarMoveletFrames: Writable<{ [frameno: number]: number }> =
   writable({});
 export const videoTableData: Writable<JSON> = writable();
+export const maxDistances: Writable<{ [metric: string]: number }> =
+  writable({"cosine": .05, "euclidean": 37, "view_invariant": .1});


### PR DESCRIPTION
The main change here is the addition of a search parameters formlet in the FrameDetails component, modifications to the API endpoints and DB queries to apply these settings (min-max limits on Euclidean or cosine distance, total # of matches to return) to similar pose and movelet searches, and a few changes (mostly behind the scenes) to how the UI handles the search results.

Attempts also were made to reduce (if not eliminate) TypeScript and other linting errors, mostly on the front-end, but in the API/DB Python code as well.