### PR TITLE
API and UI changes to search for poses across all videos in the DB

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -227,14 +227,14 @@ async def faces_by_frame(video_id: UUID, frame: int, request: Request):
     )
 
 
-# compares a known pose from the DB to others in the same video (c.f. "search_nearest_")
+# compares a known pose from the DB to others in the DB (c.f. "search_nearest_")
 @mime_api.get(
-    "/poses/similar/{max_results}/{metric_and_max}/{video_id}/{frame}/{pose_idx}/{avoid_shot}/"
+    "/poses/similar/{max_results}/{metric_and_max}/{video_param}/{frame}/{pose_idx}/{avoid_shot}/"
 )
 async def get_nearest_poses(
     max_results: int,
     metric_and_max: str,
-    video_id: UUID,
+    video_param: UUID | str,
     frame: int,
     pose_idx: int,
     avoid_shot: int,
@@ -251,7 +251,7 @@ async def get_nearest_poses(
         embedding = "global3d_coco13"
 
     frame_data = await request.app.state.db.get_nearest_poses(
-        video_id,
+        video_param,
         frame,
         pose_idx,
         metric,
@@ -267,12 +267,12 @@ async def get_nearest_poses(
     )
 
 
-# searches a video for similar poses to pose coords from webcam or other source
-@mime_api.get("/poses/similar/{max_results}/{metric_and_max}/{video_id}/{coords}/")
+# searches the DB for similar poses to pose coords from webcam or other source
+@mime_api.get("/poses/similar/{max_results}/{metric_and_max}/{video_param}/{coords}/")
 async def search_nearest_poses(
     max_results: int,
     metric_and_max: str,
-    video_id: UUID,
+    video_param: UUID | str,
     coords: str,
     request: Request,
 ):
@@ -295,7 +295,7 @@ async def search_nearest_poses(
         embedding = "global3d_coco13"
 
     frame_data = await request.app.state.db.search_by_pose(
-        video_id,
+        video_param,
         query_pose,
         metric,
         embedding,

--- a/web-ui/src/ambient.d.ts
+++ b/web-ui/src/ambient.d.ts
@@ -36,6 +36,7 @@ type VideoRecord = {
 
 type PoseRecord = {
   video_id: number;
+  video_name: string;
   frame: number;
   pose_idx: number;
   keypoints: Coco13SkeletonNoConfidence;

--- a/web-ui/src/svelte/FrameDetails.svelte
+++ b/web-ui/src/svelte/FrameDetails.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { SlideToggle } from "@skeletonlabs/skeleton";
   import {
     currentVideo,
     currentFrame,
     currentPose,
     currentMoveletPose,
+    searchAllVideos,
     searchThresholds,
   } from "@svelte/stores";
   import { formatSeconds } from "@utils";
@@ -31,19 +33,29 @@
     <h3>Details for frame #{$currentFrame}</h3>
   </header>
   <div class="flex">
-    <dl class="grid grid-cols-2 gap-2 p-4 [&>dt]:font-bold w-2/3">
-      <dt>#Tracked Poses:</dt>
-      <dd>{trackCt}</dd>
-      <dt>#Detected Faces:</dt>
-      <dd>{faceCt}</dd>
-      <dt>Time:</dt>
-      <dd>{formatSeconds(($currentFrame || 0) / $currentVideo.fps)}</dd>
-      <dt>Shot:</dt>
-      <dd>{shot}</dd>
-      <dt>Interest:</dt>
-      <dd>{(interest * 100).toFixed(2)}%</dd>
-    </dl>
-
+    <div class="flex flex-col w-2/3">
+      <dl class="grid grid-cols-2 gap-1 p-4 [&>dt]:font-bold">
+        <dt>#Tracked Poses:</dt>
+        <dd>{trackCt}</dd>
+        <dt>#Detected Faces:</dt>
+        <dd>{faceCt}</dd>
+        <dt>Time:</dt>
+        <dd>{formatSeconds(($currentFrame || 0) / $currentVideo.fps)}</dd>
+        <dt>Shot:</dt>
+        <dd>{shot}</dd>
+        <dt>Interest:</dt>
+        <dd>{(interest * 100).toFixed(2)}%</dd>
+      </dl>
+      <div class="flex pl-4">
+        <SlideToggle
+          name="search-all-toggle"
+          bind:checked={$searchAllVideos}
+          size="sm"
+        >
+          Search all videos
+        </SlideToggle>
+      </div>
+    </div>
     {#if showSearchSettings}
       <div class="grid w-1/3 gap-1 p-4 search-settings">
         <form>
@@ -152,7 +164,7 @@
       {#each poses as pose, i}
         <!-- svelte-ignore a11y-mouse-events-have-key-events -->
         <li
-          class="px-4 py-1 flex items-center gap-2 justify-between cursor-pointer"
+          class="py-1 px-2 flex items-center gap-2 justify-between cursor-pointer"
           class:variant-ghost={hoveredPoseIdx === i}
           on:mouseover={() => (hoveredPoseIdx = i)}
           on:mouseout={() => (hoveredPoseIdx = undefined)}

--- a/web-ui/src/svelte/stores.ts
+++ b/web-ui/src/svelte/stores.ts
@@ -15,6 +15,9 @@ export const currentMoveletPose: Writable<PoseRecord | null> =
 export const similarMoveletFrames: Writable<{ [frameno: number]: number }> =
   writable({});
 export const videoTableData: Writable<JSON> = writable();
+
+export const searchAllVideos: Writable<boolean> = writable(false);
+
 export const searchThresholds: Writable<{ [metric: string]: number }> =
   writable({
     cosine: 0.05,


### PR DESCRIPTION
This PR should follow in sequence after #22 and #23 are merged.
As noted in the commit, the UI for displaying the search results from other videos is deeply unsatisfactory, but it at least demonstrates that this kind of searching can be done, with query poses poses sourced from either the current video or the webcam.
No changes to the DB are needed to make this work.