### PR TITLE
Modal Frame Viewer

### DIFF
--- a/web-ui-mk2/src/components/Frame.svelte
+++ b/web-ui-mk2/src/components/Frame.svelte
@@ -1,0 +1,120 @@
+<script>
+	import { page } from '$app/stores';
+	import { LayerCake, Canvas, Html, Svg } from 'layercake';
+	import Pose from './Pose.svelte';
+
+	/**
+	 * @typedef {Object} FrameProps
+	 * @property {VideoRecord} video
+	 * @property {number} frame
+	 * @property {PoseRecord[]} poseData
+	 * @property {number} selectedPoseIdx
+	 */
+
+	/** @type {FrameProps} */
+	let { video, frame, poseData, selectedPoseIdx } = $props();
+	const { id: videoId, width: frameWidth, height: frameHeight } = video;
+
+	let displayWidthPx = $state();
+	let scaleFactor = $derived(displayWidthPx / frameWidth);
+</script>
+
+<div
+	bind:clientWidth={displayWidthPx}
+	class="frame-display"
+	style="
+	  aspect-ratio: {frameWidth}/{frameHeight};
+		width: min(80vw, {frameWidth}px, calc(80vh * ({frameWidth}/{frameHeight})) 
+	"
+>
+	<LayerCake>
+		<Html zIndex={0}>
+			<img
+				src="{$page.data.apiBase}/frame/{videoId}/{frame}/"
+				alt="Frame {frame}"
+				style="width: 100%; aspect-ratio: {frameWidth}/{frameHeight}"
+			/>
+		</Html>
+		{#if poseData && poseData.length}
+			{#each poseData as pose}
+				<Canvas zIndex={1}>
+					<Pose
+						poseData={pose.keypoints}
+						pose4dhData={pose.keypoints4dh}
+						faceData={pose.face_landmarks}
+						{scaleFactor}
+						fitToCanvas={false}
+					/>
+				</Canvas>
+			{/each}
+			<Svg viewBox="0 0 {frameWidth} {frameHeight}" zIndex={2}>
+				<defs>
+					<filter x="0" y="0" width="1" height="1" id="solid">
+						<feFlood flood-color="white" result="bg" />
+						<feMerge>
+							<feMergeNode in="bg" />
+							<feMergeNode in="SourceGraphic" />
+						</feMerge>
+					</filter>
+				</defs>
+				{#each poseData as pose, i}
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<rect
+						data-id={i}
+						x={pose.bbox[0]}
+						y={pose.bbox[1]}
+						height={pose.bbox[3]}
+						width={pose.bbox[2]}
+						class:selected={selectedPoseIdx === pose.pose_idx}
+					/>
+					{#if pose.face_bbox}
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<rect
+							x={pose.face_bbox[0]}
+							y={pose.face_bbox[1]}
+							height={pose.face_bbox[3]}
+							width={pose.face_bbox[2]}
+							class:face={true}
+							class:selected={selectedPoseIdx === pose.pose_idx}
+						/>
+					{/if}
+					<text x={pose.bbox[0] + 2} y={pose.bbox[1] + 5}>
+						#{pose.pose_idx + 1}
+					</text>
+				{/each}
+			</Svg>
+		{/if}
+	</LayerCake>
+</div>
+
+<style>
+	rect {
+		cursor: pointer;
+		fill: none;
+		pointer-events: visible;
+		stroke-width: 4;
+		stroke: white;
+
+		&.selected,
+		&:hover {
+			fill-opacity: 0.2;
+			fill: white;
+			stroke-width: 10;
+			stroke: red;
+		}
+	}
+
+	text {
+		dominant-baseline: hanging;
+		fill: white;
+		font-size: 100px;
+		stroke: white;
+	}
+
+	.frame-display {
+		background: radial-gradient(circle at 50% -250%, #333, #111827, #333);
+		box-shadow: inset 0px 0px 30px 0px #666;
+	}
+</style>

--- a/web-ui-mk2/src/components/FrameModal.svelte
+++ b/web-ui-mk2/src/components/FrameModal.svelte
@@ -1,10 +1,12 @@
 <script>
+	import CloseFilled from 'carbon-icons-svelte/lib/CloseFilled.svelte';
 	import { getPoseData } from '$lib/data-fetching';
 	import Frame from './Frame.svelte';
 	import Modal from '../ui-components/Modal.svelte';
 
-	let showModal = $state(false);
+	let modal = $state();
 
+	/** @type {VideoRecord|undefined} */
 	let video = $state();
 	let frame = $state();
 	let framePoseData = $state();
@@ -20,21 +22,81 @@
 		frame = _frame;
 		selectedPoseIdx = _selectedPoseIdx;
 		framePoseData = await getPoseData(video.id, frame);
-		showModal = true;
+		modal.show();
 	};
 </script>
 
 {#snippet body()}
 	{#if video}
 		<Frame {video} {frame} poseData={framePoseData} {selectedPoseIdx} />
+		<div class="overlay">
+			<span>
+				{video.video_name}, Frame {frame}
+			</span>
+			<div class="controls">
+				<button onclick={modal.close}><CloseFilled /></button>
+			</div>
+		</div>
 	{/if}
 {/snippet}
 
-<Modal bind:showModal {body} class="frame-modal" />
+<Modal bind:this={modal} {body} class="frame-modal" />
 
 <style>
 	:global(dialog.frame-modal) {
 		/* override the default max-width defined in Modal.svelte */
 		max-width: fit-content;
+		overflow: hidden;
+
+		:global(&:hover) .overlay {
+			opacity: 1;
+		}
+	}
+
+	.overlay {
+		color: white;
+		height: 100%;
+		left: 0;
+		opacity: 0;
+		pointer-events: none;
+		position: absolute;
+		top: 0;
+		transition: opacity 0.3s;
+		width: 100%;
+		z-index: 100;
+
+		span,
+		.controls {
+			background-color: rgba(0, 0, 0, 0.5);
+			box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+			font-size: 1.3rem;
+			padding: 10px;
+			pointer-events: all;
+		}
+		span {
+			left: 0;
+			position: absolute;
+			top: 0;
+		}
+
+		.controls {
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
+
+		button {
+			background: none;
+			border: none;
+			color: white;
+			cursor: pointer;
+			font-size: 12px;
+			transform-origin: center;
+			transition: scale 0.1s;
+
+			&:hover {
+				scale: 1.3;
+			}
+		}
 	}
 </style>

--- a/web-ui-mk2/src/components/FrameModal.svelte
+++ b/web-ui-mk2/src/components/FrameModal.svelte
@@ -1,0 +1,40 @@
+<script>
+	import { getPoseData } from '$lib/data-fetching';
+	import Frame from './Frame.svelte';
+	import Modal from '../ui-components/Modal.svelte';
+
+	let showModal = $state(false);
+
+	let video = $state();
+	let frame = $state();
+	let framePoseData = $state();
+	let selectedPoseIdx = $state();
+
+	/**
+	 * @param {VideoRecord} _video
+	 * @param {number} _frame
+	 * @param {number} _selectedPoseIdx
+	 */
+	export const show = async (_video, _frame, _selectedPoseIdx) => {
+		video = _video;
+		frame = _frame;
+		selectedPoseIdx = _selectedPoseIdx;
+		framePoseData = await getPoseData(video.id, frame);
+		showModal = true;
+	};
+</script>
+
+{#snippet body()}
+	{#if video}
+		<Frame {video} {frame} poseData={framePoseData} {selectedPoseIdx} />
+	{/if}
+{/snippet}
+
+<Modal bind:showModal {body} class="frame-modal" />
+
+<style>
+	:global(dialog.frame-modal) {
+		/* override the default max-width defined in Modal.svelte */
+		max-width: fit-content;
+	}
+</style>

--- a/web-ui-mk2/src/components/Pose.svelte
+++ b/web-ui-mk2/src/components/Pose.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import { scaleCanvas } from 'layercake';
-	import { drawPoseOnCanvas, segmentKeypoints } from '$lib/pose-utils';
+	import { drawPoseOnCanvas } from '$lib/pose-utils';
 
 	/**
 	 * @typedef {Object} PoseProps
@@ -12,7 +12,7 @@
 	 */
 
 	/** @type {PoseProps} */
-	let { poseData, scaleFactor = 1, normalizedPose = false } = $props();
+	let { poseData, scaleFactor = 1, normalizedPose = false, fitToCanvas = true } = $props();
 
 	const { width, height } = getContext('LayerCake');
 	const { ctx } = getContext('canvas');
@@ -23,7 +23,7 @@
 			// (see https://layercake.graphics/guide#scalecanvas)
 			scaleCanvas($ctx, $width, $height);
 			$ctx.clearRect(0, 0, $width, $height);
-			drawPoseOnCanvas($ctx, poseData, true);
+			drawPoseOnCanvas($ctx, poseData, fitToCanvas, scaleFactor);
 		}
 	});
 </script>

--- a/web-ui-mk2/src/components/PoseCard.svelte
+++ b/web-ui-mk2/src/components/PoseCard.svelte
@@ -1,7 +1,10 @@
 <script>
+	import { getContext } from 'svelte';
+
 	import { page } from '$app/stores';
 	import { LayerCake, Canvas, Html } from 'layercake';
 	import { getKeypointsBounds } from '$lib/pose-utils';
+	import FrameModal from './FrameModal.svelte';
 	import Pose from './Pose.svelte';
 
 	/**
@@ -12,6 +15,17 @@
 
 	/** @type {SearchResultsProps} */
 	let { sourcePose, showPose } = $props();
+
+	let frameModal = $state();
+
+	const videoData = getContext('videoData');
+
+	const showFrameModal = async () => {
+		const video = (await videoData).videos.find(
+			(/** @type {VideoRecord} */ video) => video.id === sourcePose.video_id
+		);
+		frameModal.show(video, sourcePose.frame, sourcePose.pose_idx);
+	};
 </script>
 
 <div>
@@ -39,8 +53,11 @@
 		<span>{sourcePose.video_name}</span>
 		<span>Frame {sourcePose.frame} (#{sourcePose.pose_idx + 1})</span>
 		<!-- <span>Time: {formatSeconds(sourcePose.frame / sourcePose.video.fps)}</span> -->
+		<button onclick={() => showFrameModal()}>Show Frame</button>
 	</aside>
 </div>
+
+<FrameModal bind:this={frameModal} />
 
 <style>
 	div {
@@ -54,22 +71,22 @@
 	}
 
 	aside {
+		background: var(--panel-background);
 		display: flex;
-		padding: 0.5rem;
-		background: aliceblue;
 		flex-direction: column;
 		gap: 0.5rem;
+		padding: 0.5rem;
 	}
 
 	img {
 		height: 100%;
-		width: 100%;
 		object-fit: contain;
 		opacity: 0;
-		transform: scale(1.1);
 		transform-origin: center;
+		transform: scale(1.1);
 		transition:
 			opacity 0.5s,
 			transform 0.7s;
+		width: 100%;
 	}
 </style>

--- a/web-ui-mk2/src/components/SearchResults.svelte
+++ b/web-ui-mk2/src/components/SearchResults.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { setContext } from 'svelte';
 	import { page } from '$app/stores';
 
 	import PoseCard from './PoseCard.svelte';
@@ -37,7 +38,9 @@
 	}
 
 	const getVideoData = async () => {
-		return await fetch(`${$page.data.apiBase}/videos/`).then((data) => data.json());
+		const videoData = fetch(`${$page.data.apiBase}/videos/`).then((data) => data.json());
+		setContext('videoData', videoData);
+		return await videoData;
 	};
 </script>
 

--- a/web-ui-mk2/src/lib/data-fetching.js
+++ b/web-ui-mk2/src/lib/data-fetching.js
@@ -1,0 +1,14 @@
+import { get } from 'svelte/store';
+import { page } from '$app/stores';
+
+/**
+ * Fetches pose data from the API for a given video and frame.
+ *
+ * @param {string} videoId - The ID of the video to fetch.
+ * @param {number} frame - The frame number to fetch.
+ * @return {Promise<PoseRecord[]>} A Promise that resolves to the pose data.
+ */
+export const getPoseData = async (videoId, frame) => {
+	const response = await fetch(`${get(page).data.apiBase}/poses/${videoId}/${frame}/`);
+	return await response.json();
+};

--- a/web-ui-mk2/src/lib/pose-utils.js
+++ b/web-ui-mk2/src/lib/pose-utils.js
@@ -118,16 +118,16 @@ export const drawPoseOnCanvas = (context, poseData, fitToCanvas) => {
 	let yAdjust = 0;
 
 	if (fitToCanvas) {
-		const [xMin, yMin, width, height] = getKeypointsBounds(poseData, false)
+		const [xMin, yMin, width, height] = getKeypointsBounds(poseData, /* hasConfidence= */ false);
 		const xMid = (xMin * 2 + width) / 2;
 		const yMid = (yMin * 2 + height) / 2;
 
 		if (width > height) {
 			scaleFactor = context.canvas.width / width;
-			yAdjust = (yMin-yMid) * scaleFactor / 2;
+			yAdjust = ((yMin - yMid) * scaleFactor) / 2;
 		} else {
 			scaleFactor = context.canvas.height / height;
-			xAdjust = (xMin-xMid) * scaleFactor / 2;
+			xAdjust = ((xMin - xMid) * scaleFactor) / 2;
 		}
 	}
 

--- a/web-ui-mk2/src/lib/pose-utils.js
+++ b/web-ui-mk2/src/lib/pose-utils.js
@@ -111,8 +111,7 @@ export const shiftNormalizeRescaleKeypoints = (keypoints) => {
  * @param {boolean} fitToCanvas
  * @returns {void}
  */
-export const drawPoseOnCanvas = (context, poseData, fitToCanvas) => {
-	let scaleFactor = 1;
+export const drawPoseOnCanvas = (context, poseData, fitToCanvas, scaleFactor = 1) => {
 	const segments = segmentKeypoints(poseData, poseData.length / (COCO_13_SKELETON.length - 1));
 	let xAdjust = 0;
 	let yAdjust = 0;

--- a/web-ui-mk2/src/lib/pose-utils.js
+++ b/web-ui-mk2/src/lib/pose-utils.js
@@ -112,8 +112,8 @@ export const shiftNormalizeRescaleKeypoints = (keypoints) => {
  * @returns {void}
  */
 export const drawPoseOnCanvas = (context, poseData, fitToCanvas) => {
-	const segments = segmentKeypoints(poseData, 2);
 	let scaleFactor = 1;
+	const segments = segmentKeypoints(poseData, poseData.length / (COCO_13_SKELETON.length - 1));
 	let xAdjust = 0;
 	let yAdjust = 0;
 

--- a/web-ui-mk2/src/ui-components/Modal.svelte
+++ b/web-ui-mk2/src/ui-components/Modal.svelte
@@ -2,31 +2,40 @@
 	/**
 	 * @typedef {Object} ModalProps
 	 * @property {boolean} showModal
-	 * @property {import('svelte').Snippet} header
+	 * @property {import('svelte').Snippet} [header]
 	 * @property {import('svelte').Snippet} body
+	 * @property {string} [class]
 	 */
 
 	/** @type {ModalProps} */
-	let { showModal = $bindable(false), header, body } = $props();
+	let { showModal = $bindable(false), header, body, ...props } = $props();
 
 	let /** @type {HTMLDialogElement} */ dialog;
 
+	export const show = () => {
+		dialog.showModal();
+	};
+
+	export const close = () => {
+		dialog.close();
+	};
+
 	$effect(() => {
-		if (dialog && showModal) dialog.showModal();
+		if (dialog && showModal) show();
 	});
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<dialog bind:this={dialog} onclose={() => (showModal = false)}>
+<dialog bind:this={dialog} onclose={() => (showModal = false)} {...props}>
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div>
+	{#if header}
 		{@render header()}
 		<hr />
-		{@render body()}
-		<hr />
-		<button onclick={() => dialog.close()}>close modal</button>
-	</div>
+	{/if}
+	{@render body()}
+	<hr />
+	<button onclick={() => dialog.close()}>close modal</button>
 </dialog>
 
 <style>
@@ -39,10 +48,6 @@
 
 	dialog::backdrop {
 		background: rgba(0, 0, 0, 0.3);
-	}
-
-	dialog > div {
-		padding: 1em;
 	}
 
 	dialog[open] {

--- a/web-ui-mk2/src/ui-components/Modal.svelte
+++ b/web-ui-mk2/src/ui-components/Modal.svelte
@@ -1,0 +1,77 @@
+<script>
+	/**
+	 * @typedef {Object} ModalProps
+	 * @property {boolean} showModal
+	 * @property {import('svelte').Snippet} header
+	 * @property {import('svelte').Snippet} body
+	 */
+
+	/** @type {ModalProps} */
+	let { showModal = $bindable(false), header, body } = $props();
+
+	let /** @type {HTMLDialogElement} */ dialog;
+
+	$effect(() => {
+		if (dialog && showModal) dialog.showModal();
+	});
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<dialog bind:this={dialog} onclose={() => (showModal = false)}>
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div>
+		{@render header()}
+		<hr />
+		{@render body()}
+		<hr />
+		<button onclick={() => dialog.close()}>close modal</button>
+	</div>
+</dialog>
+
+<style>
+	dialog {
+		max-width: 32em;
+		border-radius: 0.2em;
+		border: none;
+		padding: 0;
+	}
+
+	dialog::backdrop {
+		background: rgba(0, 0, 0, 0.3);
+	}
+
+	dialog > div {
+		padding: 1em;
+	}
+
+	dialog[open] {
+		animation: zoom 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+
+	@keyframes zoom {
+		from {
+			transform: scale(0.95);
+		}
+		to {
+			transform: scale(1);
+		}
+	}
+
+	dialog[open]::backdrop {
+		animation: fade 0.2s ease-out;
+	}
+
+	@keyframes fade {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	button {
+		display: block;
+	}
+</style>

--- a/web-ui-mk2/src/ui-components/Modal.svelte
+++ b/web-ui-mk2/src/ui-components/Modal.svelte
@@ -1,7 +1,7 @@
 <script>
 	/**
 	 * @typedef {Object} ModalProps
-	 * @property {boolean} showModal
+	 * @property {boolean} [showModal=false]
 	 * @property {import('svelte').Snippet} [header]
 	 * @property {import('svelte').Snippet} body
 	 * @property {string} [class]
@@ -34,8 +34,6 @@
 		<hr />
 	{/if}
 	{@render body()}
-	<hr />
-	<button onclick={() => dialog.close()}>close modal</button>
 </dialog>
 
 <style>


### PR DESCRIPTION
This PR adds a `<Frame/>` component which is intended to be reusable (although it is not yet feature complete), a `<Modal/>` component (which is also intended to be reusable), and `<FrameModal/>` component which puts the two together.  Nothing here is completely finished or as flexible and reusable as I'd like (and the use of context, in particular, is a false start that will be quickly superseded), but I think I'm going to keep PRing small waypoints like this to give you opportunities to comment along the way as this new container is developed.  Thanks :)