### PR TITLE
Fix pose/hand hover highlighting in 2D frame view, scaling of pose track labels

### DIFF
--- a/api/mime_db/_read_only.py
+++ b/api/mime_db/_read_only.py
@@ -265,6 +265,7 @@ async def get_nearest_poses(
                  pose.keypoints,
                  {distance} AS distance,
                  frame.shot AS shot,
+                 face.landmarks AS face_landmarks,
                  face.cluster_id AS face_cluster_id
           FROM pose
             INNER JOIN video ON video.id = pose.video_id

--- a/web-ui/src/svelte/FrameDisplay.svelte
+++ b/web-ui/src/svelte/FrameDisplay.svelte
@@ -43,6 +43,7 @@
               <Pose
                 poseData={poseData.keypointsopp}
                 pose4dhData={poseData.keypoints4dh}
+                faceData={poseData.face_landmarks}
                 leftHandData={poseData.lh_keypoints_2d}
                 rightHandData={poseData.rh_keypoints_2d}
                 {scaleFactor}

--- a/web-ui/src/svelte/FrameDisplay.svelte
+++ b/web-ui/src/svelte/FrameDisplay.svelte
@@ -18,6 +18,7 @@
   export let displayWidthPx = 640;
 
   const scaleFactor = displayWidthPx / frameWidth;
+  const labelFontSize = `${Math.max(8, Math.round(16 / scaleFactor))}px`;
 </script>
 
 <div>
@@ -147,6 +148,7 @@
                 y={poseData.bbox[1] + 5}
                 stroke="white"
                 fill="white"
+                font-size={labelFontSize}
               >
                 {#if poseData.track_id !== null}
                   {poseData.track_id}

--- a/web-ui/src/svelte/FrameDisplay.svelte
+++ b/web-ui/src/svelte/FrameDisplay.svelte
@@ -73,8 +73,8 @@
                 stroke={poseData.track_id ? "magenta" : "white"}
                 fill="none"
                 stroke-width="1"
-                class:selected={hoveredPoseIdx === i}
-                on:mouseover={() => (hoveredPoseIdx = i)}
+                class:selected={hoveredPoseIdx === poseData.pose_idx}
+                on:mouseover={() => (hoveredPoseIdx = poseData.pose_idx)}
                 on:mouseout={() => (hoveredPoseIdx = undefined)}
                 on:click={() => ($currentPose = poses[i])}
                 pointer-events="visible"
@@ -89,9 +89,9 @@
                   stroke="limegreen"
                   fill="none"
                   stroke-width="1"
-                  class:selected={hoveredPoseIdx === i}
-                  on:mouseover={() => (hoveredPoseIdx = i)}
-                  on:focus={() => (hoveredPoseIdx = i)}
+                  class:selected={hoveredPoseIdx === poseData.pose_idx}
+                  on:mouseover={() => (hoveredPoseIdx = poseData.pose_idx)}
+                  on:focus={() => (hoveredPoseIdx = poseData.pose_idx)}
                   on:mouseout={() => (hoveredPoseIdx = undefined)}
                   on:blur={() => (hoveredPoseIdx = undefined)}
                   pointer-events="visible"
@@ -107,9 +107,9 @@
                   stroke="green"
                   fill="none"
                   stroke-width="1"
-                  class:selected={hoveredPoseIdx === i}
-                  on:mouseover={() => (hoveredPoseIdx = i)}
-                  on:focus={() => (hoveredPoseIdx = i)}
+                  class:selected={hoveredPoseIdx === poseData.pose_idx}
+                  on:mouseover={() => (hoveredPoseIdx = poseData.pose_idx)}
+                  on:focus={() => (hoveredPoseIdx = poseData.pose_idx)}
                   on:mouseout={() => (hoveredPoseIdx = undefined)}
                   on:blur={() => (hoveredPoseIdx = undefined)}
                   on:click={() => {
@@ -129,9 +129,9 @@
                   stroke="red"
                   fill="none"
                   stroke-width="1"
-                  class:selected={hoveredPoseIdx === i}
-                  on:mouseover={() => (hoveredPoseIdx = i)}
-                  on:focus={() => (hoveredPoseIdx = i)}
+                  class:selected={hoveredPoseIdx === poseData.pose_idx}
+                  on:mouseover={() => (hoveredPoseIdx = poseData.pose_idx)}
+                  on:focus={() => (hoveredPoseIdx = poseData.pose_idx)}
                   on:mouseout={() => (hoveredPoseIdx = undefined)}
                   on:blur={() => (hoveredPoseIdx = undefined)}
                   on:click={() => {


### PR DESCRIPTION
I think this might as well go in now. The changes only affect the mk1 UX -- although it's probably worth incorporating some version of the font scaling technique for the mk2 frame view.

I considered adjusting the code to take advantage of the fact that hand data is now returned in the pose data query, but that could get tricky and it's probably not worth bothering with for now.