### PR TITLE
DB Fixes

### DIFF
--- a/api/match_hands_to_poses.py
+++ b/api/match_hands_to_poses.py
@@ -611,8 +611,6 @@ async def main() -> None:
                 video_id, hands_to_match, min_frameno, max_frameno, db, model_path
             )
 
-    await db.index_pose_hands()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/api/mime_db/__init__.py
+++ b/api/mime_db/__init__.py
@@ -45,7 +45,6 @@ class MimeDb:
         assign_pose_interest,
         clear_actions,
         clear_poses,
-        index_pose_hands,
         load_4dh_predictions,
         load_lart_predictions,
         load_openpifpaf_predictions,

--- a/api/mime_db/_data_loading.py
+++ b/api/mime_db/_data_loading.py
@@ -326,7 +326,7 @@ async def add_video_tracks(self, video_id: UUID | None, track_data) -> None:
 
 
 async def load_lart_predictions(
-    self, video_id: UUID, pkl_path: Path, clear=True, reindex=False
+    self, video_id: UUID, pkl_path: Path, clear=True
 ) -> None:
     if clear:
         logging.debug(f"Clearing actions for video {video_id}")
@@ -366,16 +366,6 @@ async def load_lart_predictions(
     )
 
     logging.info(f"Loaded {len(data)} action predictions!")
-
-    if reindex:
-        logging.info("Building action search index")
-        await self._pool.execute(
-            """
-            CREATE INDEX ON pose
-            USING ivfflat (ava_action vector_cosine_ops)
-            ;
-            """,
-        )
 
 
 async def add_video_faces(self, video_id: UUID | None, faces_data) -> None:
@@ -451,32 +441,7 @@ async def add_pose_hands(self, hands_data) -> None:
     logging.info(f"Loaded {len(hands_data)} matched hands!")
 
 
-async def index_pose_hands(self) -> None:
-    logging.info("Building hand search index")
-    await self._pool.execute(
-        """
-        CREATE INDEX ON hand
-        USING ivfflat (joint_angles3d vector_cosine_ops)
-        ;
-        """,
-    )
-    await self._pool.execute(
-        """
-        CREATE INDEX ON hand
-        USING ivfflat (class_weights vector_cosine_ops)
-        ;
-        """,
-    )
-    await self._pool.execute(
-        """
-        CREATE INDEX ON hand
-        USING ivfflat (rectified3d vector_cosine_ops)
-        ;
-        """,
-    )
-
-
-async def add_video_movelets(self, movelets_data, reindex=False) -> None:
+async def add_video_movelets(self, movelets_data) -> None:
     data = [tuple(movelet) for movelet in movelets_data]
     await self._pool.executemany(
         """
@@ -501,19 +466,8 @@ async def add_video_movelets(self, movelets_data, reindex=False) -> None:
 
     logging.info(f"Loaded {len(movelets_data)} movelets!")
 
-    if reindex:
-        logging.info("Creating approximate distance index for movelets...")
-        async with self._pool.acquire() as conn:
-            await conn.execute(
-                """
-                CREATE INDEX ON movelet
-                USING ivfflat (motion vector_cosine_ops)
-                ;
-                """,
-            )
 
-
-async def assign_poem_embeddings(self, poem_data, reindex=False) -> None:
+async def assign_poem_embeddings(self, poem_data) -> None:
     async with self._pool.acquire() as conn:
         await conn.execute(
             "ALTER TABLE pose ADD COLUMN IF NOT EXISTS poem_embedding vector(16) DEFAULT NULL;"
@@ -527,18 +481,6 @@ async def assign_poem_embeddings(self, poem_data, reindex=False) -> None:
             """,
             poem_data,
         )
-
-        if reindex:
-            logging.info(
-                "Creating approximate index for cosine distance of viewpoint-invariant pose embeddings..."
-            )
-            await conn.execute(
-                """
-                CREATE INDEX ON pose
-                USING ivfflat (poem_embedding vector_cosine_ops)
-                ;
-                """,
-            )
 
         return
 
@@ -633,7 +575,6 @@ async def annotate_pose(
     col_type: str,
     video_id: UUID | None,
     annotation_func: Callable,
-    reindex=False,
     pose_tbl="pose",
 ) -> None:
     async with self._pool.acquire() as conn:
@@ -665,15 +606,14 @@ async def annotate_pose(
                     pose["pose_idx"],
                 )
 
-        if reindex:
-            logging.info("Creating approximate index for cosine distance...")
-            await conn.execute(
-                f"""
-                CREATE INDEX ON {pose_tbl}
-                USING ivfflat ({column} vector_cosine_ops)
-                ;
-                """,
-            )
+        # logging.info("Creating approximate index for cosine distance...")
+        await conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS {pose_tbl}_{column}_idx ON {pose_tbl}
+              USING ivfflat ({column} vector_cosine_ops)
+            ;
+            """,
+        )
     return
 
 

--- a/api/mime_db/_initialization.py
+++ b/api/mime_db/_initialization.py
@@ -200,7 +200,7 @@ async def initialize_db(conn, drop=False) -> None:
                 pose_details.track_ct,
                 pose_details.face_ct,
                 pose_details.hand_ct,
-                1 - pose_details.avg_score,
+                pose_details.avg_score,
                 CAST(frame.is_shot_boundary AS INT) AS is_shot,
                 frame.pose_interest,
                 frame.action_interest,

--- a/api/mime_db/_initialization.py
+++ b/api/mime_db/_initialization.py
@@ -9,6 +9,7 @@ async def initialize_db(conn, drop=False) -> None:
         await conn.execute("DROP TABLE IF EXISTS movelet CASCADE;")
         await conn.execute("DROP TABLE IF EXISTS face CASCADE;")
         await conn.execute("DROP TABLE IF EXISTS frame CASCADE;")
+        await conn.execute("DROP TABLE IF EXISTS hand CASCADE;")
 
     await conn.execute(
         """

--- a/api/mime_db/_initialization.py
+++ b/api/mime_db/_initialization.py
@@ -70,6 +70,11 @@ async def initialize_db(conn, drop=False) -> None:
             PRIMARY KEY(video_id, frame, pose_idx)
         )
         ;
+
+        CREATE INDEX IF NOT EXISTS pose_poem_embedding_idx ON pose
+          USING ivfflat (poem_embedding vector_cosine_ops);
+        CREATE INDEX IF NOT EXISTS pose_ava_action_idx ON pose
+          USING ivfflat (ava_action vector_cosine_ops);
         """
     )
 
@@ -112,6 +117,13 @@ async def initialize_db(conn, drop=False) -> None:
             cluster_id INTEGER DEFAULT NULL
         )
         ;
+
+        CREATE INDEX IF NOT EXISTS hand_joint_angles3d_idx ON hand
+          USING ivfflat (joint_angles3d vector_cosine_ops);
+        CREATE INDEX IF NOT EXISTS hand_class_weights_idx ON hand
+          USING ivfflat (class_weights vector_cosine_ops);
+        CREATE INDEX IF NOT EXISTS hand_rectified3d_idx ON hand
+          USING ivfflat (rectified3d vector_cosine_ops);
         """
     )
 
@@ -134,6 +146,9 @@ async def initialize_db(conn, drop=False) -> None:
             PRIMARY KEY(video_id, track_id, tick)
         )
         ;
+
+        CREATE INDEX IF NOT EXISTS movelet_motion_idx ON movelet
+          USING ivfflat (motion vector_cosine_ops);
         """
     )
 
@@ -172,7 +187,7 @@ async def initialize_db(conn, drop=False) -> None:
             ORDER BY video_name
         WITH DATA;
 
-        CREATE UNIQUE INDEX ON video_meta (id);
+        CREATE UNIQUE INDEX IF NOT EXISTS video_meta_id_idx ON video_meta (id);
         """
     )
 
@@ -223,7 +238,8 @@ async def initialize_db(conn, drop=False) -> None:
         ORDER BY pose_details.frame
         WITH DATA;
 
-        CREATE INDEX ON video_frame_meta (video_id);
+        CREATE INDEX IF NOT EXISTS video_frame_meta_video_id_idx
+          ON video_frame_meta (video_id);
         """
     )
 


### PR DESCRIPTION
This PR fixes three separate issues with database management code:

1. acf9200 ensures that INDEXes are created once and only once (this is achieved in part by giving them fixed names instead of auto-generated ones).
2. 9d92624 ensures that the `hand` table is properly DROPped when the DB is reinitialized.
3. ddabcaf fixes an issue with the incorrect creation of the `avg_score` column for the `video_frame_meta` VIEW.