### PR TITLE
DB and Ingestion Fixes

### DIFF
--- a/api/mime_db/_data_loading.py
+++ b/api/mime_db/_data_loading.py
@@ -304,14 +304,27 @@ async def load_lart_predictions(
 
     action_updates = []
 
-    track_frames = await self.get_track_frames(video_id)
+    track_frames = [
+        track_frame["frame"] for track_frame in await self.get_track_frames(video_id)
+    ]
+
+    errors = {
+        "No action for frame": 0,
+        "No track for frame": 0,
+        "No tracked ids for frame": 0,
+    }
 
     for _, frame in frames.items():
-        if (
-            (frame["time"] + 1) not in track_frames
-            or len(frame["tracked_ids"]) == 0
-            or "ava_action" not in frame
-        ):
+        if "ava_action" not in frame:
+            errors["No action for frame"] += 1
+            continue
+
+        if (frame["time"] + 1) not in track_frames:
+            errors["No track for frame"] += 1
+            continue
+
+        if len(frame["tracked_ids"]) == 0:
+            errors["No tracked ids for frame"] += 1
             continue
 
         for tracked_id in frame["tracked_ids"]:
@@ -336,6 +349,8 @@ async def load_lart_predictions(
     )
 
     logging.info(f"Loaded {len(data)} action predictions!")
+
+    logging.info(f"Errors: {errors}")
 
 
 async def add_video_faces(self, video_id: UUID | None, faces_data) -> None:

--- a/api/mime_db/_initialization.py
+++ b/api/mime_db/_initialization.py
@@ -5,11 +5,13 @@ async def initialize_db(conn, drop=False) -> None:
     if drop:
         logging.warning("Dropping database tables...")
         await conn.execute("DROP TABLE IF EXISTS video CASCADE;")
-        await conn.execute("DROP TABLE IF EXISTS pose CASCADE;")
-        await conn.execute("DROP TABLE IF EXISTS movelet CASCADE;")
-        await conn.execute("DROP TABLE IF EXISTS face CASCADE;")
         await conn.execute("DROP TABLE IF EXISTS frame CASCADE;")
+        await conn.execute("DROP TABLE IF EXISTS pose CASCADE;")
+        await conn.execute("DROP TABLE IF EXISTS face CASCADE;")
         await conn.execute("DROP TABLE IF EXISTS hand CASCADE;")
+        await conn.execute("DROP TABLE IF EXISTS movelet CASCADE;")
+        await conn.execute("DROP MATERIALIZED VIEW IF EXISTS video_meta CASCADE;")
+        await conn.execute("DROP MATERIALIZED VIEW IF EXISTS video_meta_frame CASCADE;")
 
     await conn.execute(
         """


### PR DESCRIPTION
This PR has two small "fixes":

1. Ensures that the `MATERIALIZED VIEW`s are dropped when the DB is reset (spent a couple of minutes chasing red-herrings because of this oversight 😠)
2. When checking whether a frame has been included in the database, `frame["time"] + 1` should be compared to `track_frame["frame"]`.