### PR TITLE
Avoid having "bad" score values paint over the timeline when sampling frames

### DIFF
--- a/api/mime_db/_read_only.py
+++ b/api/mime_db/_read_only.py
@@ -25,7 +25,7 @@ async def get_pose_data_by_frame(self, video_id: UUID) -> list:
                track_ct AS "trackCt",
                face_ct AS "faceCt",
                hand_ct AS "handCt",
-               1 - avg_score AS "badScore",
+               1 - NULLIF(avg_score, 0) AS "badScore",
                is_shot AS "isShot",
                movement,
                movement3d,


### PR DESCRIPTION
This continues the saga from commit #51 (and earlier) involving the inversion of the frame-level average pose confidence value into a pose "badness" score for the timeline visualization, which was done so that it would behave similarly to the other sequences (usually staying near 0 and only spiking up near the top of the plot at relevant moments); previous to this the "confidence" line hovered around 90-99% most of the time and rarely descended to the bottom of the plot, which arguably made the entire plot more confusing.

Introducing the ability to sample every nth frame made things more complicated, because non-sampled frames are (prior to this PR) visualized as having confidence = 0 and therefore badness = 1, with the result that the artificial ping-ponging of the badness values between 1 and close to 0 every n frames paints pretty much the entire timeline fuchsia. Because the current detection system does not produce poses with 0% confidence (typically the imported poses are restricted to those with confidence of >80%), it suffices for timeline-drawing purposes to consider any frame with 0 confidence (which includes all of the non-sampled frames) as having 0% badness, rather than 100%.

It's worth noting that other metrics that are visualized on the timeline have somewhat similar "painting" problems when sampling every nth frame, but the confidence/badness value is by far the worst offender for the reasons described above, hence this change. The other series also have much more legitimate reasons for reading 0 or 100% at times, so this simple (if hacky) fix wouldn't work for them anyway.